### PR TITLE
Feature/removing nodejs only libs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "channelape-sdk",
-  "version": "1.1.0",
+  "version": "1.1.0-develop.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.1.0",
+	"version": "1.1.0-develop.1",
 	"description": "A client for interacting with ChannelApe's API",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
This pull request only contains 2 commits that up the package version to use a -develop.1

All the work required was already on the develop branch, I would like -develop.1 to be published to NPM in order to truly user test without relying on npm link.