### PR TITLE
Feature/fixing imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.2.0-develop.1",
+	"version": "1.2.0-develop.2",
 	"description": "A client for interacting with ChannelApe's API",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/RequestClientWrapper.ts
+++ b/src/RequestClientWrapper.ts
@@ -4,7 +4,7 @@ import ChannelApeError from './model/ChannelApeError';
 import HttpRequestMethod from './model/HttpRequestMethod';
 import RequestResponse from './model/RequestResponse';
 import { RequestCallback } from './model/RequestCallback';
-import RequestClientWrapperConfiguration from '../src/model/RequestClientWrapperConfiguration';
+import RequestClientWrapperConfiguration from './model/RequestClientWrapperConfiguration';
 
 const GENERIC_ERROR_CODE = -1;
 


### PR DESCRIPTION
Auto import strikes again.

The issue is that during development (and testing) the import "../../../src/..." works because that file exists. However once it is transpiled there is no "src" folder, only "dist". This commit fixes this issue.

The "../../../src/..." imports found in tests are okay because they actually need to reference the TS files.

Maybe there is a linting option we could adjust to ensure silly things like this don't slip by. I'm still interested in having a VSCode extension for ChannelApe integration development, maybe it can handle stuff like this if linting can't.