### PR TITLE
Feature/adding ecconrefused and esockettimedout retry unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.2.0-develop.1",
+	"version": "1.2.0-develop.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.2.0-develop.2",
+	"version": "1.2.0-develop.3",
 	"description": "A client for interacting with ChannelApe's API",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/model/RequestResponse.ts
+++ b/src/model/RequestResponse.ts
@@ -4,4 +4,5 @@ export default interface RequestResponse {
   error: Error | undefined;
   response: AxiosResponse | undefined;
   body: any;
+  code?: string;
 }

--- a/src/utils/RequestLogger.ts
+++ b/src/utils/RequestLogger.ts
@@ -41,10 +41,22 @@ export default class RequestLogger {
     }
   }
 
-  public logResponse(error: any, response: AxiosResponse | undefined | null, body: any | undefined): void {
+  public logResponse(
+    error: any,
+    response: AxiosResponse | undefined | null,
+    body: any | undefined,
+    code?: string | undefined
+  ): void {
     let errorMessage: string;
     let infoMessage = '';
-    if (response != null && typeof response.config !== 'undefined') {
+    if (code && response) {
+      const errorMessage =
+        `${response.config.method} ${response.config.url} ` +
+        `-- FAILED WITH STATUS: ${code}`;
+      if (this.logger !== undefined) {
+        this.logger.warn(errorMessage);
+      }
+    } else if (response != null && typeof response.config !== 'undefined') {
       if (!this.responseIsLevel200(response.status)) {
         const errorMessage =
           `${response.config.method} ${response.config.url} ` +

--- a/test/sessions/service/SessionsService.spec.ts
+++ b/test/sessions/service/SessionsService.spec.ts
@@ -6,16 +6,17 @@ import axios from 'axios';
 import SessionsService from './../../../src/sessions/service/SessionsService';
 import Version from '../../../src/model/Version';
 import Resource from '../../../src/model/Resource';
-import Environment from '../../../src/model/Environment';
 import ChannelApeApiErrorResponse from '../../../src/model/ChannelApeApiErrorResponse';
 import RequestClientWrapper from '../../../src/RequestClientWrapper';
+
+const endpoint = 'https://fake-api.test.com';
 
 describe('Sessions Service', () => {
 
   describe('Given some rest client and session ID ', () => {
     const client: RequestClientWrapper =
       new RequestClientWrapper({
-        endpoint: Environment.STAGING,
+        endpoint,
         maximumRequestRetryTimeout: 10000,
         timeout: 60000,
         session: 'valid-session-id',


### PR DESCRIPTION
I added unit tests to ensure that when axios returns an ECCONNABORTED (timeout) or a low level "Network Error" the calls are retried.

I also changed the Sessions spec to use fake-api.test.com as it was still using the CA staging endpoint.