### PR TITLE
Hotfix/1.2.1

### DIFF
--- a/e2e/ChannelApeClient.spec.ts
+++ b/e2e/ChannelApeClient.spec.ts
@@ -145,6 +145,23 @@ describe('ChannelApe Client', () => {
       });
     });
 
+    describe('And valid order', () => {
+      context('When updating order', () => {
+        it('Then update the order', () => {
+          const expectedOrderId = '3bc9120d-b706-49cd-ad81-6445ce77d8ad';
+          return channelApeClient.orders().get(expectedOrderId).then((actualOrder) => {
+            expect(actualOrder.id).to.equal(expectedOrderId);
+            const randomName = Math.random().toString();
+            actualOrder.customer!.name! = randomName;
+            return channelApeClient.orders().update(actualOrder).then((actualUpdatedOrder) => {
+              expect(actualUpdatedOrder.id).to.equal(actualUpdatedOrder);
+              expect(actualUpdatedOrder.customer!.name!).to.equal(randomName);
+            });
+          });
+        });
+      });
+    });
+
     describe('And valid business ID', () => {
       describe('And a startDate of "2018-03-29T17:00:51.000Z" and an endDate of "2018-08-23T12:41:33.000Z"', () => {
         context('When retrieving orders', () => {

--- a/e2e/ChannelApeClient.spec.ts
+++ b/e2e/ChannelApeClient.spec.ts
@@ -151,11 +151,17 @@ describe('ChannelApe Client', () => {
           const expectedOrderId = '3bc9120d-b706-49cd-ad81-6445ce77d8ad';
           return channelApeClient.orders().get(expectedOrderId).then((actualOrder) => {
             expect(actualOrder.id).to.equal(expectedOrderId);
-            const randomName = Math.random().toString();
-            actualOrder.customer!.name! = randomName;
+            const randomFirstName = Math.random().toString();
+            const randomLastName = Math.random().toString();
+            const fullName = `${randomFirstName} ${randomLastName}`;
+            actualOrder.customer!.firstName! = randomFirstName;
+            actualOrder.customer!.lastName! = randomLastName;
+            actualOrder.customer!.name! = fullName;
             return channelApeClient.orders().update(actualOrder).then((actualUpdatedOrder) => {
-              expect(actualUpdatedOrder.id).to.equal(actualUpdatedOrder);
-              expect(actualUpdatedOrder.customer!.name!).to.equal(randomName);
+              expect(actualUpdatedOrder.id).to.equal(actualUpdatedOrder.id);
+              expect(actualUpdatedOrder.customer!.firstName!).to.equal(randomFirstName);
+              expect(actualUpdatedOrder.customer!.lastName!).to.equal(randomLastName);
+              expect(actualUpdatedOrder.customer!.name!).to.equal(fullName);
             });
           });
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.2.0",
+	"version": "1.2.1-develop.0",
 	"description": "A client for interacting with ChannelApe's API",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/RequestClientWrapper.ts
+++ b/src/RequestClientWrapper.ts
@@ -72,7 +72,7 @@ export default class RequestClientWrapper {
           requestPromise = axios.get(url, options);
           break;
         case HttpRequestMethod.PUT:
-          requestPromise = axios.put(url, undefined, options);
+          requestPromise = axios.put(url, { body: options.data }, options);
           break;
         default:
           throw new ChannelApeError('HTTP Request Method could not be determined', {} as any, '', []);


### PR DESCRIPTION
@rjdavis3  This hotfix fixes PUT calls. This changes the 2nd parameter in axios.put() to be the PUT data sent in options.

Please see the first build (with just the e2e test) and see that it failed: https://travis-ci.org/ChannelApe/channelape-typescript-sdk/builds/427847215

And the 2nd build (with the e2e test and the logic update) and see that it succeeded: https://travis-ci.org/ChannelApe/channelape-typescript-sdk/builds/427857161

The current build: https://travis-ci.org/ChannelApe/channelape-typescript-sdk is just upping the package version to 1.2.1-develop.0