### PR TITLE
Line Item Model now properly has the "shippingTax" property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.4.0-develop.0",
+	"version": "1.4.0-develop.1",
 	"description": "A client for interacting with ChannelApe's API",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/orders/model/LineItem.ts
+++ b/src/orders/model/LineItem.ts
@@ -6,7 +6,7 @@ export default interface LineItem {
   id: string;
   price?: number;
   shippingPrice?: number;
-  shippingtax?: number;
+  shippingTax?: number;
   quantity: number;
   shippingMethod?: string;
   sku?: string;


### PR DESCRIPTION
Before this commit the "T" was lower case and that was incorrect.

See https://www.channelape.com/support/knowledgebase/pulling-orders-shopify-channelape/ to verify the capitalization is correct.