### PR TITLE
ChannelsService.get(channelsRequestByBusinessId) now returns an array

### DIFF
--- a/e2e/ChannelApeClient.spec.ts
+++ b/e2e/ChannelApeClient.spec.ts
@@ -122,15 +122,15 @@ describe('ChannelApe Client', () => {
           const actualChannelsPromise = channelApeClient.channels().get({
             businessId: expectedBusinessId
           });
-          return actualChannelsPromise.then((actualChannels) => {
-            expect(actualChannels.channels).to.be.an('array');
+          return actualChannelsPromise.then((channels) => {
+            expect(channels).to.be.an('array');
             let i: number;
-            for (i = 0; i < actualChannels.channels.length; i += 1) {
-              if (actualChannels.channels[i].id === '9c728601-0286-457d-b0d6-ec19292d4485') {
+            for (i = 0; i < channels.length; i += 1) {
+              if (channels[i].id === '9c728601-0286-457d-b0d6-ec19292d4485') {
                 break;
               }
             }
-            assertChannelEuropaSportsSnackFoods(actualChannels.channels[i]);
+            assertChannelEuropaSportsSnackFoods(channels[i]);
           });
         });
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.4.0-develop.1",
+	"version": "1.4.0-develop.2",
 	"description": "A client for interacting with ChannelApe's API",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/channels/service/ChannelsService.ts
+++ b/src/channels/service/ChannelsService.ts
@@ -17,9 +17,9 @@ export default class ChannelsService {
   constructor(private readonly client: RequestClientWrapper) { }
 
   public get(channelId: string): Promise<Channel>;
-  public get(channelsQueryRequestByBusinessId: ChannelsQueryRequestByBusinessId): Promise<ChannelsResponse>;
+  public get(channelsQueryRequestByBusinessId: ChannelsQueryRequestByBusinessId): Promise<Channel[]>;
   public get(channelIdOrRequest: string | ChannelsQueryRequestByBusinessId):
-    Promise<Channel> | Promise<ChannelsResponse> {
+    Promise<Channel> | Promise<Channel[]> {
     if (typeof channelIdOrRequest === 'string') {
       return this.getChannelById(channelIdOrRequest);
     }
@@ -35,7 +35,7 @@ export default class ChannelsService {
     return deferred.promise as any;
   }
 
-  private getChannelsByRequest(channelsRequest: ChannelsQueryRequestByBusinessId): Promise<ChannelsResponse> {
+  private getChannelsByRequest(channelsRequest: ChannelsQueryRequestByBusinessId): Promise<Channel[]> {
     return new Promise((resolve) => {
       const requestUrl = `/${Version.V1}${Resource.CHANNELS}`;
       const options: AxiosRequestConfig = {
@@ -69,16 +69,13 @@ export default class ChannelsService {
     requestUrl: string,
     requestCallbackParams: RequestCallbackParams,
     expectedStatusCode: number
-  ): Promise<ChannelsResponse> {
+  ): Promise<Channel[]> {
     return new Promise((resolve, reject) => {
       if (requestCallbackParams.error) {
         reject(requestCallbackParams.error);
       } else if (requestCallbackParams.response.status === expectedStatusCode) {
         const data: ChannelsResponse = requestCallbackParams.body as ChannelsResponse;
-        resolve({
-          channels: data.channels.map(channel => this.formatChannel(channel)),
-          errors: data.errors
-        });
+        resolve(data.channels.map(channel => this.formatChannel(channel)));
       } else {
         const channelApeErrorResponse =
           GenerateApiError(requestUrl, requestCallbackParams.response, requestCallbackParams.body,

--- a/test/channels/service/ChannelsService.spec.ts
+++ b/test/channels/service/ChannelsService.spec.ts
@@ -151,11 +151,11 @@ describe('Channels Service', () => {
       const channelsService: ChannelsService = new ChannelsService(client);
       return channelsService.get({
         businessId: '4baafa5b-4fbf-404e-9766-8a02ad45c3a4'
-      }).then((actualChannelResponse) => {
+      }).then((actualChannelsResponse) => {
         expect(clientGetStub.args[0][0])
           .to.equal(`/${Version.V1}${Resource.CHANNELS}`);
         expect(clientGetStub.args[0][1].params.businessId).to.equal('4baafa5b-4fbf-404e-9766-8a02ad45c3a4');
-        expectChannel(actualChannelResponse.channels[0]);
+        expectChannel(actualChannelsResponse[0]);
       });
     });
 


### PR DESCRIPTION
@rjdavis3  This new call to ChannelsService.get(requestByBusinessId) currently returns a "ChannelResponse" object, that is:

`{
  channels: Channel[];
  errors: ChannelApeError[];
}`

I had originally intended for this because I was under the mistaken assumption that the Channels endpoint had pagination. However as you pointed out there is no pagination so instead of having users do this:

`channelApeClient.channels().get({ businessId: 'valid' })
  .then((response) => {
     f(response.channels); // response.channels is an array of Channel objects
  })`

We could have the user do this:

`channelApeClient.channels().get({ businessId: 'valid' })
  .then((channels) => {
     f(channels); // channels is an array of Channel objects
  })`

I thought it was cleaner this way as when you use channelApeClient.orders().get({ businessId: 'valid' }) you end up with an array of orders, not an object with an orders property.