### PR TITLE
Feature/add url encoding to variant service

### DIFF
--- a/e2e/ChannelApeClient.spec.ts
+++ b/e2e/ChannelApeClient.spec.ts
@@ -281,7 +281,7 @@ describe('ChannelApe Client', () => {
     describe('And valid business ID', () => {
       describe('And a startDate of "2018-03-29T17:00:51.000Z" and an endDate of "2018-08-23T12:41:33.000Z"', () => {
         context('When retrieving orders', () => {
-          it('Then return the 228 orders between those dates', () => {
+          it('Then return the 229 orders between those dates', () => {
             const expectedBusinessId = '4baafa5b-4fbf-404e-9766-8a02ad45c3a4';
             const ordersQueryRequestByBusinessId: OrdersQueryRequestByBusinessId = {
               businessId: expectedBusinessId,
@@ -291,7 +291,7 @@ describe('ChannelApe Client', () => {
             const actualOrdersPromise = channelApeClient.orders().get(ordersQueryRequestByBusinessId);
             return actualOrdersPromise.then((actualOrders) => {
               expect(actualOrders).to.be.an('array');
-              expect(actualOrders.length).to.equal(228);
+              expect(actualOrders.length).to.equal(229);
               expect(actualOrders[0].id).to.equal('dda8a05f-d5dd-4535-9261-b55c501085ef');
             });
           });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.5.0-develop.0",
+	"version": "1.5.0-develop.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.5.0-develop.0",
+	"version": "1.5.0-develop.2",
 	"description": "A client for interacting with ChannelApe's API",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/variants/service/VariantsService.ts
+++ b/src/variants/service/VariantsService.ts
@@ -94,7 +94,7 @@ export default class VariantsService {
 
   private getVariantByRequest(variantRequest: VariantsRequest, deferred: Q.Deferred<any>): void {
     const requestUrl = `/${Version.V1}${Resource.PRODUCTS}/${variantRequest.productId}${Resource.VARIANTS}/` +
-      `${variantRequest.inventoryItemValue}`;
+      `${encodeURIComponent(variantRequest.inventoryItemValue)}`;
     const options: AxiosRequestConfig = { };
     this.client.get(requestUrl, options, (error, response, body) => {
       const requestResponse: RequestCallbackParams = {

--- a/test/variants/service/VariantService.spec.ts
+++ b/test/variants/service/VariantService.spec.ts
@@ -201,6 +201,33 @@ describe('VariantsService', () => {
       });
     });
 
+    describe('And valid productId and valid variantId that needs to be URL encoded', () => {
+      context('When retrieving a variant', () => {
+        it('Then URL encode the variantId and return that variant', () => {
+          const expectedProductId = '0744f2de-c62c-4b04-907f-26699463c0bd';
+          const sku = '317-01-549-10/12';
+          const urlEncodedSku = '317-01-549-10%2F12';
+          const variantsRequest: VariantsRequest = {
+            productId: expectedProductId,
+            inventoryItemValue: sku
+          };
+
+          const mockedAxiosAdapter = new axiosMockAdapter(axios);
+          const baseUrl = `${Environment.STAGING}/${Version.V1}${Resource.PRODUCTS}`;
+          mockedAxiosAdapter.onGet(`${baseUrl}/${expectedProductId}${Resource.VARIANTS}/${urlEncodedSku}`)
+            .reply(200, getVariantResult);
+
+          const actualVariantPromise = variantsService.get(variantsRequest);
+          return actualVariantPromise.then((actualVariant) => {
+            expect(actualVariant.options.Flavor).to.equal('Chocolate');
+            expect(actualVariant.additionalFields.walmartBrand).to.equal('MusclePharm');
+            expect(actualVariant.retailPrice).to.equal(59.99);
+            expect(actualVariant.title).to.equal('MusclePharm Sport Series Combat XL Mass Gainer');
+          });
+        });
+      });
+    });
+
     describe('And valid businessId and valid vendor', () => {
       context('When searching variants', () => {
         it('Then return variant quick search results', () => {


### PR DESCRIPTION
@rjdavis3  This PR will resolve searching variants within the CA API with SKUs such as: **317-01-549-10/12** by URL Encoding them.