### PR TITLE
Feature/refund model

### DIFF
--- a/e2e/ChannelApeClient.spec.ts
+++ b/e2e/ChannelApeClient.spec.ts
@@ -163,6 +163,21 @@ describe('ChannelApe Client', () => {
           });
         });
       });
+
+      context('When retrieving order with a refund', () => {
+        it('Then return order', () => {
+          const expectedOrderId = '2a94d852-5b3e-4dd4-ba2b-cec8295f2318';
+          const actualOrderPromise = channelApeClient.orders().get(expectedOrderId);
+          return actualOrderPromise.then((actualOrder) => {
+            expect(actualOrder.id).to.equal(expectedOrderId);
+            expect(actualOrder.businessId).to.equal('4baafa5b-4fbf-404e-9766-8a02ad45c3a4');
+            expect(actualOrder.status).to.equal(OrderStatus.OPEN);
+            expect(actualOrder.refunds![0].lineItems[0].quantity).to.equal(2);
+            expect(actualOrder.refunds![0].channelRefundId).to.equal('74273487234');
+            expect(actualOrder.refunds![0].supplierRefundId).to.equal('7348234');
+          });
+        });
+      });
     });
 
     describe('And valid order', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.5.0-develop.2",
+	"version": "1.5.0-develop.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.5.0-develop.2",
+	"version": "1.5.0-develop.3",
 	"description": "A client for interacting with ChannelApe's API",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export { default as Address } from './orders/model/Address';
 export { default as Customer } from './orders/model/Customer';
 export { default as Fulfillment } from './orders/model/Fulfillment';
 export { default as LineItem } from './orders/model/LineItem';
+export { default as Refund } from './orders/model/Refund';
 export { default as Order } from './orders/model/Order';
 export { default as OrderCreateRequest } from './orders/model/OrderCreateRequest';
 export { default as OrdersQueryRequestByBusinessId } from './orders/model/OrdersQueryRequestByBusinessId';

--- a/src/orders/model/Order.ts
+++ b/src/orders/model/Order.ts
@@ -3,6 +3,7 @@ import Fulfillment from './Fulfillment';
 import AdditionalField from '../../model/AdditionalField';
 import OrderStatus from './OrderStatus';
 import Customer from './Customer';
+import Refund from './Refund';
 
 export default interface Order {
   additionalFields?: AdditionalField[];
@@ -26,4 +27,5 @@ export default interface Order {
   alphabeticCurrencyCode: string;
   lineItems: LineItem[];
   fulfillments?: Fulfillment[];
+  refunds?: Refund[];
 }

--- a/src/orders/model/Refund.ts
+++ b/src/orders/model/Refund.ts
@@ -1,0 +1,7 @@
+import LineItem from './LineItem';
+
+export default interface Refund {
+  supplierRefundId?: string;
+  channelRefundId?: string;
+  lineItems: LineItem[];
+}

--- a/test/model/Resources.spec.ts
+++ b/test/model/Resources.spec.ts
@@ -14,4 +14,22 @@ describe('Resources', () => {
   it('ORDERS', () => {
     expect(Resource.ORDERS).to.equal('/orders');
   });
+  it('PRODUCTS', () => {
+    expect(Resource.PRODUCTS).to.equal('/products');
+  });
+  it('SKUS', () => {
+    expect(Resource.SKUS).to.equal('/skus');
+  });
+  it('TAGS', () => {
+    expect(Resource.TAGS).to.equal('/tags');
+  });
+  it('UPCS', () => {
+    expect(Resource.UPCS).to.equal('/upcs');
+  });
+  it('VARIANTS', () => {
+    expect(Resource.VARIANTS).to.equal('/variants');
+  });
+  it('VENDORS', () => {
+    expect(Resource.VENDORS).to.equal('/vendors');
+  });
 });

--- a/test/variants/model/VariantCondition.spec.ts
+++ b/test/variants/model/VariantCondition.spec.ts
@@ -1,0 +1,16 @@
+import VariantCondition from '../../../src/variants/model/VariantCondition';
+import { expect } from 'chai';
+
+describe('VariantCondition', () => {
+  it('NEW', () => {
+    expect(VariantCondition.NEW).to.equal('NEW');
+  });
+
+  it('REFURBISHED', () => {
+    expect(VariantCondition.REFURBISHED).to.equal('REFURBISHED');
+  });
+
+  it('USED', () => {
+    expect(VariantCondition.USED).to.equal('USED');
+  });
+});


### PR DESCRIPTION
@rjdavis3  This PR adds the Refund model to the CA SDK. I also rose mutation coverage with specs on some ENUMs.