### PR TITLE
Feature/get subscriptions

### DIFF
--- a/e2e/ChannelApeClient.spec.ts
+++ b/e2e/ChannelApeClient.spec.ts
@@ -498,6 +498,28 @@ describe('ChannelApe Client', () => {
         });
       });
     });
+
+    describe('And valid businessId with an active subscription', () => {
+      context('When getting subscription', () => {
+        it('Then return subscription result', () => {
+          const expectedBusinessId = '4baafa5b-4fbf-404e-9766-8a02ad45c3a4';
+          const actualSubscriptionsPromise = channelApeClient.subscriptions().get(expectedBusinessId);
+          return actualSubscriptionsPromise.then((actualSubscription) => {
+            expect(actualSubscription.active).to.equal(true);
+            expect(actualSubscription.businessId).to.equal(expectedBusinessId);
+            expect(actualSubscription.createdAt!.toISOString()).to.be.a('string');
+            expect(actualSubscription.errors).to.be.an('array');
+            expect(actualSubscription.errors.length).to.equal(0);
+            expect(actualSubscription.lastCompletedTaskUsageRecordingTime!.toISOString()).to.be.a('string');
+            expect(actualSubscription.periodEndsAt!.toISOString()).to.be.a('string');
+            expect(actualSubscription.periodStartedAt!.toISOString()).to.be.a('string');
+            expect(actualSubscription.subscriptionId).to.not.equal(undefined);
+            expect(actualSubscription.subscriptionProductHandle).to.not.equal(undefined);
+            expect(actualSubscription.updatedAt!.toISOString()).to.be.a('string');
+          });
+        });
+      });
+    });
   });
 
   function getSessionId(): string {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.6.0",
+	"version": "1.7.0-develop.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.6.0",
+	"version": "1.7.0-develop.0",
 	"description": "A client for interacting with ChannelApe's API",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/ChannelApeClient.ts
+++ b/src/ChannelApeClient.ts
@@ -8,6 +8,7 @@ import VariantsService from './variants/service/VariantsService';
 import BusinessesService from './businesses/service/BusinessesService';
 import Environment from './model/Environment';
 import SessionsService from './sessions/service/SessionsService';
+import SubscriptionsService from './subscriptions/service/SubscriptionsService';
 
 const MISSING_SESSION_ID_ERROR_MESSAGE = 'sessionId is required.';
 const MINIMUM_REQUEST_RETRY_RANDOM_DELAY_TOO_SMALL_ERROR_MESSAGE =
@@ -36,6 +37,7 @@ export default class ChannelApeClient {
   private readonly variantsService: VariantsService;
   private readonly businessesService: BusinessesService;
   private readonly sessionsService: SessionsService;
+  private readonly subscriptionsService: SubscriptionsService;
 
   constructor(clientConfiguration: ClientConfiguration) {
     const configurationErrors = this.validateConfiguration(clientConfiguration);
@@ -74,6 +76,7 @@ export default class ChannelApeClient {
     this.variantsService = new VariantsService(this.requestClientWrapper);
     this.businessesService = new BusinessesService(this.requestClientWrapper);
     this.sessionsService = new SessionsService(this.requestClientWrapper);
+    this.subscriptionsService = new SubscriptionsService(this.requestClientWrapper);
   }
 
   get SessionId(): string {
@@ -118,6 +121,10 @@ export default class ChannelApeClient {
 
   sessions(): SessionsService {
     return this.sessionsService;
+  }
+
+  subscriptions(): SubscriptionsService {
+    return this.subscriptionsService;
   }
 
   private validateConfiguration(clientConfiguration: ClientConfiguration): string | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { default as ClientConfiguration } from './model/ClientConfiguration';
 export { default as Session } from './sessions/model/Session';
+export { default as Subscription } from './subscriptions/model/Subscription';
 export { default as Business } from './businesses/model/Business';
 export { default as BusinessesQueryRequestByUserId } from './businesses/model/BusinessesQueryRequestByUserId';
 export { default as BusinessesQueryRequestByBusinessId } from './businesses/model/BusinessesQueryRequestByBusinessId';

--- a/src/model/Resource.ts
+++ b/src/model/Resource.ts
@@ -1,5 +1,6 @@
 enum Resource {
   SESSIONS = '/sessions',
+  SUBSCRIPTIONS = '/subscriptions',
   ACTIONS = '/actions',
   CHANNELS = '/channels',
   ORDERS = '/orders',

--- a/src/subscriptions/model/Subscription.ts
+++ b/src/subscriptions/model/Subscription.ts
@@ -1,0 +1,14 @@
+import ChannelApeApiError from '../../../src/model/ChannelApeApiError';
+
+export default interface Subscription {
+  active?: boolean;
+  businessId?: string;
+  createdAt?: Date;
+  errors: ChannelApeApiError[];
+  lastCompletedTaskUsageRecordingTime?: Date;
+  periodEndsAt?: Date;
+  periodStartedAt?: Date;
+  subscriptionId?: string;
+  subscriptionProductHandle?: string;
+  updatedAt?: Date;
+}

--- a/src/subscriptions/service/SubscriptionsService.ts
+++ b/src/subscriptions/service/SubscriptionsService.ts
@@ -1,0 +1,58 @@
+import * as Q from 'q';
+import Subscription from './../model/Subscription';
+import ChannelApeApiErrorResponse from './../../model/ChannelApeApiErrorResponse';
+import Resource from '../../model/Resource';
+import Version from '../../model/Version';
+import RequestClientWrapper from '../../RequestClientWrapper';
+
+export default class SubscriptionsService {
+
+  constructor(private readonly client: RequestClientWrapper) { }
+
+  get(businessId: string): Q.Promise<Subscription> {
+    const deferred = Q.defer<Subscription>();
+    const requestUrl = `/${Version.V1}${Resource.SUBSCRIPTIONS}/${businessId}`;
+
+    this.client.get(requestUrl, {}, (error, response, body) => {
+      if (error) {
+        deferred.reject(error);
+      } else if (response.status === 200) {
+        deferred.resolve(this.formatSubscription(body));
+      } else {
+        const channelApeApiErrorResponse = body as ChannelApeApiErrorResponse;
+        channelApeApiErrorResponse.statusCode = response.status;
+        deferred.reject(channelApeApiErrorResponse);
+      }
+    });
+    return deferred.promise;
+  }
+
+  private formatSubscription(subscriptionResponse: any): Subscription {
+    const subscription: Subscription = {
+      errors: subscriptionResponse.errors
+    };
+    subscription.active = subscriptionResponse.active;
+    subscription.businessId = subscriptionResponse.businessId;
+    subscription.subscriptionId = subscriptionResponse.subscriptionId;
+    subscription.subscriptionProductHandle = subscriptionResponse.subscriptionProductHandle;
+
+    if (subscriptionResponse.createdAt) {
+      subscription.createdAt = new Date(subscriptionResponse.createdAt);
+    }
+    if (subscriptionResponse.lastCompletedTaskUsageRecordingTime) {
+      subscription.lastCompletedTaskUsageRecordingTime =
+        new Date(subscriptionResponse.lastCompletedTaskUsageRecordingTime);
+    }
+    if (subscriptionResponse.periodEndsAt) {
+      subscription.periodEndsAt = new Date(subscriptionResponse.periodEndsAt);
+    }
+    if (subscriptionResponse.periodStartedAt) {
+      subscription.periodStartedAt = new Date(subscriptionResponse.periodStartedAt);
+    }
+    if (subscriptionResponse.updatedAt) {
+      subscription.updatedAt = new Date(subscriptionResponse.updatedAt);
+    }
+    return subscription;
+  }
+
+}

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -388,4 +388,12 @@ describe('Index', () => {
     expect(variantsSearchRequestByTag.tag).to.equal('tag');
   });
 
+  it('Expect Subscription to be exported', () => {
+    const subscription: ChannelApe.Subscription = {
+      active: true,
+      errors: []
+    };
+    expect(subscription.active).to.equal(true);
+  });
+
 });

--- a/test/subscriptions/service/SubscriptionService.spec.ts
+++ b/test/subscriptions/service/SubscriptionService.spec.ts
@@ -1,0 +1,201 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import LogLevel from '../../../src/model/LogLevel';
+import axios from 'axios';
+
+import SubscriptionsService from './../../../src/subscriptions/service/SubscriptionsService';
+import Version from '../../../src/model/Version';
+import Resource from '../../../src/model/Resource';
+import ChannelApeApiErrorResponse from '../../../src/model/ChannelApeApiErrorResponse';
+import RequestClientWrapper from '../../../src/RequestClientWrapper';
+
+const endpoint = 'https://fake-api.test.com';
+
+describe('Subscriptions Service', () => {
+
+  describe('Given some rest client and session ID ', () => {
+    const client: RequestClientWrapper =
+      new RequestClientWrapper({
+        endpoint,
+        maximumRequestRetryTimeout: 10000,
+        timeout: 60000,
+        session: 'valid-session-id',
+        logLevel: LogLevel.INFO,
+        minimumRequestRetryRandomDelay: 50,
+        maximumRequestRetryRandomDelay: 50
+      });
+    const active = true;
+    const businessId = 'f6ed6f7a-47bf-4dd3-baed-71a8a9684e80';
+    const createdAt = '2018-02-22T16:03:42.662Z';
+    const errors: any = [];
+    const lastCompletedTaskUsageRecordingTime = '2018-04-02T00:00:00.000Z';
+    const periodEndsAt = '2019-02-08T16:03:11.000Z';
+    const periodStartedAt = '2019-01-08T16:03:11.000Z';
+    const subscriptionId = '1701701';
+    const subscriptionProductHandle = 'fake-handle';
+    const updatedAt = '2019-01-08T16:20:45.865Z';
+    const subscriptionsService = new SubscriptionsService(client);
+
+    let sandbox: sinon.SinonSandbox;
+
+    beforeEach((done) => {
+      sandbox = sinon.createSandbox();
+      done();
+    });
+
+    afterEach((done) => {
+      sandbox.restore();
+      done();
+    });
+
+    it('And subscription ID is valid ' +
+      'When retrieving subscription Then return resolved promise with subscription data', () => {
+
+      const expectedResponse = {
+        active,
+        businessId,
+        createdAt,
+        errors,
+        lastCompletedTaskUsageRecordingTime,
+        periodEndsAt,
+        periodStartedAt,
+        subscriptionId,
+        subscriptionProductHandle,
+        updatedAt
+      };
+
+      const response = {
+        status: 200,
+        config: {},
+        data: expectedResponse
+      };
+
+      const clientGetStub = sandbox.stub(axios, 'get').resolves(response);
+
+      return subscriptionsService.get(businessId).then((actualResponse) => {
+        expect(clientGetStub.args[0][0])
+            .to.equal(`/${Version.V1}${Resource.SUBSCRIPTIONS}/${businessId}`);
+        expect(actualResponse.active).to.equal(active);
+        expect(actualResponse.businessId).to.equal(businessId);
+        expect(actualResponse.createdAt!.toISOString()).to.equal(createdAt);
+        expect(actualResponse.errors.length).to.equal(0);
+        expect(actualResponse.lastCompletedTaskUsageRecordingTime!.toISOString())
+          .to.equal(lastCompletedTaskUsageRecordingTime);
+        expect(actualResponse.periodEndsAt!.toISOString()).to.equal(periodEndsAt);
+        expect(actualResponse.periodStartedAt!.toISOString()).to.equal(periodStartedAt);
+        expect(actualResponse.subscriptionId).to.equal(subscriptionId);
+        expect(actualResponse.subscriptionProductHandle).to.equal(subscriptionProductHandle);
+        expect(actualResponse.updatedAt!.toISOString()).to.equal(updatedAt);
+      });
+    });
+
+    it('And subscription ID is valid ' +
+      'When retrieving subscription Then return resolved promise with subscription data', () => {
+
+      const expectedResponse = {
+        errors
+      };
+
+      const response = {
+        status: 200,
+        config: {},
+        data: expectedResponse
+      };
+
+      const clientGetStub = sandbox.stub(axios, 'get').resolves(response);
+
+      return subscriptionsService.get(businessId).then((actualResponse) => {
+        expect(clientGetStub.args[0][0])
+            .to.equal(`/${Version.V1}${Resource.SUBSCRIPTIONS}/${businessId}`);
+        expect(actualResponse.active).to.equal(undefined);
+        expect(actualResponse.businessId).to.equal(undefined);
+        expect(actualResponse.createdAt).to.equal(undefined);
+        expect(actualResponse.errors.length).to.equal(0);
+        expect(actualResponse.lastCompletedTaskUsageRecordingTime)
+          .to.equal(undefined);
+        expect(actualResponse.periodEndsAt).to.equal(undefined);
+        expect(actualResponse.periodStartedAt).to.equal(undefined);
+        expect(actualResponse.subscriptionId).to.equal(undefined);
+        expect(actualResponse.subscriptionProductHandle).to.equal(undefined);
+        expect(actualResponse.updatedAt).to.equal(undefined);
+      });
+    });
+
+    it('And subscription ID is valid And request connect errors ' +
+      'When retrieving subscription Then return a rejected promise with an error', (done) => {
+
+      const expectedError = {
+        stack: 'oh no an error'
+      };
+      const clientGetStub = sandbox.stub(client, 'get')
+        .yields(expectedError, null, null);
+
+      subscriptionsService.get(businessId).then((actualResponse) => {
+        expect(actualResponse).to.be.undefined;
+      }).catch((e) => {
+        expect(clientGetStub.args[0][0])
+            .to.equal(`/${Version.V1}${Resource.SUBSCRIPTIONS}/${businessId}`);
+        expect(e).to.be.equal(expectedError);
+        done();
+      });
+    });
+
+    it('And business ID is invalid ' +
+      'When retrieving subscription Then return rejected promise with 401 ' +
+      'status code and invalid auth error message', () => {
+
+      const expectedChannelApeApiErrorResponse : ChannelApeApiErrorResponse = {
+        statusCode: 401,
+        errors: [
+          {
+            code: 12,
+            message: 'Invalid authorization token. Please check the server logs and try again.'
+          }
+        ]
+      };
+      const response = {
+        status: 401,
+        config: {},
+        data: expectedChannelApeApiErrorResponse
+      };
+      const clientGetStub = sandbox.stub(axios, 'get').resolves(response);
+
+      return subscriptionsService.get(businessId).then((actualResponse) => {
+        expect(actualResponse).to.be.undefined;
+      }).catch((actualChannelApeErrorResponse) => {
+        expect(clientGetStub.args[0][0])
+          .to.equal(`/${Version.V1}${Resource.SUBSCRIPTIONS}/${businessId}`);
+        expect(actualChannelApeErrorResponse.responseStatusCode).to.equal(401);
+        expect(actualChannelApeErrorResponse.ApiErrors.length).to.equal(1);
+        expect(actualChannelApeErrorResponse.ApiErrors[0].code)
+          .to.equal(expectedChannelApeApiErrorResponse.errors[0].code);
+        expect(actualChannelApeErrorResponse.ApiErrors[0].message)
+          .to.equal(expectedChannelApeApiErrorResponse.errors[0].message);
+      });
+    });
+
+    it('And subscriptions endpoint returns a 202 erroneously ' +
+      'When retrieving subscription Then return rejected promise with 202 ' +
+      'status code and error message', () => {
+
+      const expectedChannelApeApiErrorResponse : ChannelApeApiErrorResponse = {
+        statusCode: 202,
+        errors: []
+      };
+      const response = {
+        status: 202,
+        config: {},
+        data: expectedChannelApeApiErrorResponse
+      };
+      const clientGetStub = sandbox.stub(axios, 'get').resolves(response);
+
+      return subscriptionsService.get(businessId).then((actualResponse) => {
+        expect(actualResponse).to.be.undefined;
+      }).catch((actualChannelApeErrorResponse) => {
+        expect(clientGetStub.args[0][0])
+          .to.equal(`/${Version.V1}${Resource.SUBSCRIPTIONS}/${businessId}`);
+        expect(actualChannelApeErrorResponse.statusCode).to.equal(202);
+      });
+    });
+  });
+});


### PR DESCRIPTION
@rjdavis3  Here is a PR for CA-4514 (subscriptions). This adds a Subscriptions service with get() exposed, an exported Subscription model, and unit / e2e tests.

The Travis build passed.