### PR TITLE
Hotfix/1.7.2

### DIFF
--- a/e2e/ChannelApeClient.spec.ts
+++ b/e2e/ChannelApeClient.spec.ts
@@ -7,6 +7,7 @@ import ChannelApeApiError from '../src/model/ChannelApeApiError';
 import ChannelApeClient from '../src/ChannelApeClient';
 import OrderStatus from '../src/orders/model/OrderStatus';
 import OrdersQueryRequestByBusinessId from '../src/orders/model/OrdersQueryRequestByBusinessId';
+import OrdersQueryRequestByChannelOrderId from '../src/orders/model/OrdersQueryRequestByChannelOrderId';
 import Channel from '../src/channels/model/Channel';
 import VariantsRequestByProductId from '../src/variants/model/VariantsRequestByProductId';
 import VariantsRequest from '../src/variants/model/VariantsRequest';
@@ -372,6 +373,43 @@ describe('ChannelApe Client', () => {
               expect(actualOrders.pagination.lastPage).to.equal(false);
               expect(actualOrders.pagination.totalItems)
                 .to.equal(140, 'There should be 140 totalItems in the pagination response');
+            });
+          });
+        });
+      });
+
+      describe('And a valid channelOrderId of "0.5951056075648626"', () => {
+        context('When retrieving orders', () => {
+          it('Then return a single order with that channelOrderId', () => {
+            const expectedBusinessId = '4baafa5b-4fbf-404e-9766-8a02ad45c3a4';
+            const expectedChannelOrderId = '0.5951056075648626';
+            const ordersQueryRequestByChannelOrderId: OrdersQueryRequestByChannelOrderId = {
+              businessId: expectedBusinessId,
+              channelOrderId: expectedChannelOrderId
+            };
+            const actualOrdersPromise = channelApeClient.orders().get(ordersQueryRequestByChannelOrderId);
+            return actualOrdersPromise.then((actualOrders) => {
+              expect(actualOrders).to.be.an('array');
+              expect(actualOrders.length).to.equal(1);
+              expect(actualOrders[0].channelOrderId).to.equal(expectedChannelOrderId);
+            });
+          });
+        });
+
+        context('When retrieving an orders page', () => {
+          it('Then return a single order page with one order with that channelOrderId', () => {
+            const expectedBusinessId = '4baafa5b-4fbf-404e-9766-8a02ad45c3a4';
+            const expectedChannelOrderId = '0.5951056075648626';
+            const ordersQueryRequestByChannelOrderId: OrdersQueryRequestByChannelOrderId = {
+              businessId: expectedBusinessId,
+              channelOrderId: expectedChannelOrderId
+            };
+            const actualOrderPage = channelApeClient.orders().getPage(ordersQueryRequestByChannelOrderId);
+            return actualOrderPage.then((orderPage) => {
+              expect(orderPage.pagination.lastPage).to.equal(true);
+              expect(orderPage.orders).to.be.an('array');
+              expect(orderPage.orders.length).to.equal(1);
+              expect(orderPage.orders[0].channelOrderId).to.equal(expectedChannelOrderId);
             });
           });
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"description": "A client for interacting with ChannelApe's API",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/orders/model/OrdersQueryRequestByChannelOrderId.ts
+++ b/src/orders/model/OrdersQueryRequestByChannelOrderId.ts
@@ -1,4 +1,5 @@
-export default interface OrdersRequestByChannelOrderId {
-  businessId: string;
+import OrdersQueryRequestByBusinessId from './OrdersQueryRequestByBusinessId';
+
+export default interface OrdersQueryRequestByChannelOrderId extends OrdersQueryRequestByBusinessId{
   channelOrderId: string;
 }


### PR DESCRIPTION
This fixes the Order Query Request by Channel Order ID model so that it can handle pagination values. This will make the logic for searching for a particular channel order ID on the new web app much simpler.