### PR TITLE
Added order PATCH capability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - npm install
 script:
   - npm test
-  - npm run e2e
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run e2e; fi
 after_success:
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash .travis/overwrite-sonar-project-version.sh; fi
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then sonar-scanner; fi

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ channelapeClient.orders().update(order)
   });
 ```
 
+#### Patch order
+```typescript
+channelapeClient.orders().patch(order)
+  .then((patchedOrder: Order) => {
+    // do what you need to do with patchedOrder data here
+  });
+```
+
 #### Create order
 ````typescript
 const orderToCreate: OrderCreateRequest = {

--- a/e2e/ChannelApeClient.spec.ts
+++ b/e2e/ChannelApeClient.spec.ts
@@ -208,6 +208,38 @@ describe('ChannelApe Client', () => {
       });
     });
 
+    describe('And valid order', () => {
+      context('When patching order', () => {
+        it('Then patch the order', () => {
+          const expectedOrderId = '9f53ade6-5ed0-4fa1-8361-16bdf5852eab';
+          return channelApeClient.orders().get(expectedOrderId).then((actualOrder) => {
+            expect(actualOrder.id).to.equal(expectedOrderId);
+            const randomAddress1 = `${randomNumber(1, 999999)} ${randomWord(4, 12)} Street`;
+            const randomCity = `${randomWord(6, 12)} City`;
+            const randomProvince = `${randomWord(4, 10)}`;
+            const randomProvinceCode = `${randomWord(2, 2).toUpperCase()}`;
+            if (!actualOrder.customer) {
+              actualOrder.customer = {};
+            }
+            if (!actualOrder.customer.shippingAddress) {
+              actualOrder.customer.shippingAddress = {};
+            }
+            actualOrder.customer!.shippingAddress!.address1 = randomAddress1;
+            actualOrder.customer!.shippingAddress!.city = randomCity;
+            actualOrder.customer!.shippingAddress!.province = randomProvince;
+            actualOrder.customer!.shippingAddress!.provinceCode = randomProvinceCode;
+            return channelApeClient.orders().patch(actualOrder).then((actualUpdatedOrder) => {
+              expect(actualUpdatedOrder.id).to.equal(actualUpdatedOrder.id);
+              expect(actualUpdatedOrder.customer!.shippingAddress!.address1).to.equal(randomAddress1);
+              expect(actualUpdatedOrder.customer!.shippingAddress!.city).to.equal(randomCity);
+              expect(actualUpdatedOrder.customer!.shippingAddress!.province).to.equal(randomProvince);
+              expect(actualUpdatedOrder.customer!.shippingAddress!.provinceCode).to.equal(randomProvinceCode);
+            });
+          });
+        });
+      });
+    });
+
     describe('And valid order create request', () => {
       context('When creating an order', () => {
         it('Then create the order', () => {
@@ -683,5 +715,33 @@ describe('ChannelApe Client', () => {
     expect(channel.createdAt.toISOString()).to.equal(expectedCreatedAt.toISOString());
     expect(channel.updatedAt.getUTCMilliseconds())
       .to.be.greaterThan(expectedCreatedAt.getUTCMilliseconds());
+  }
+
+  /**
+   * Generates a random number based on the provided min and max values.
+   * @param {number} min Minimum number to generate (inclusive)
+   * @param {number} max Maximum number to generate (inclusive)
+   */
+  function randomNumber(min: number, max: number): number {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  }
+
+  /**
+   * Generates a random semi-readable word based on the provided min an max length values.
+   * @param {number} min Minium word length (inclusive)
+   * @param {number} max Maximum word length (inclusive)
+   */
+  function randomWord(min: number, max: number): string {
+    const consonantsArr = 'bcdfghjlmnpqrstv'.split('');
+    const vowelsArr = 'aeiou'.split('');
+    let word = '';
+    const length = randomNumber(min, max);
+    for (let i = 0; i < length / 2; i += 1) {
+      const randConsonant = consonantsArr[randomNumber(0, consonantsArr.length - 1)];
+      const randVowel = vowelsArr[randomNumber(0, vowelsArr.length - 1)];
+      word += (i === 0) ? randConsonant.toUpperCase() : randConsonant;
+      word += i * 2 < length - 1 ? randVowel : '';
+    }
+    return word;
   }
 });

--- a/e2e/ChannelApeClient.spec.ts
+++ b/e2e/ChannelApeClient.spec.ts
@@ -214,26 +214,26 @@ describe('ChannelApe Client', () => {
           const expectedOrderId = '9f53ade6-5ed0-4fa1-8361-16bdf5852eab';
           return channelApeClient.orders().get(expectedOrderId).then((actualOrder) => {
             expect(actualOrder.id).to.equal(expectedOrderId);
-            const randomAddress1 = `${randomNumber(1, 999999)} ${randomWord(4, 12)} Street`;
-            const randomCity = `${randomWord(6, 12)} City`;
-            const randomProvince = `${randomWord(4, 10)}`;
-            const randomProvinceCode = `${randomWord(2, 2).toUpperCase()}`;
+            const fakeAddress = faker.address.streetAddress();
+            const fakeCity = faker.address.city();
+            const fakeProvince = faker.address.state();
+            const fakeProvinceCode = fakeCity.substr(0, 2).toUpperCase();
             if (!actualOrder.customer) {
               actualOrder.customer = {};
             }
             if (!actualOrder.customer.shippingAddress) {
               actualOrder.customer.shippingAddress = {};
             }
-            actualOrder.customer!.shippingAddress!.address1 = randomAddress1;
-            actualOrder.customer!.shippingAddress!.city = randomCity;
-            actualOrder.customer!.shippingAddress!.province = randomProvince;
-            actualOrder.customer!.shippingAddress!.provinceCode = randomProvinceCode;
+            actualOrder.customer!.shippingAddress!.address1 = fakeAddress;
+            actualOrder.customer!.shippingAddress!.city = fakeCity;
+            actualOrder.customer!.shippingAddress!.province = fakeProvince;
+            actualOrder.customer!.shippingAddress!.provinceCode = fakeProvinceCode;
             return channelApeClient.orders().patch(actualOrder).then((actualUpdatedOrder) => {
               expect(actualUpdatedOrder.id).to.equal(actualUpdatedOrder.id);
-              expect(actualUpdatedOrder.customer!.shippingAddress!.address1).to.equal(randomAddress1);
-              expect(actualUpdatedOrder.customer!.shippingAddress!.city).to.equal(randomCity);
-              expect(actualUpdatedOrder.customer!.shippingAddress!.province).to.equal(randomProvince);
-              expect(actualUpdatedOrder.customer!.shippingAddress!.provinceCode).to.equal(randomProvinceCode);
+              expect(actualUpdatedOrder.customer!.shippingAddress!.address1).to.equal(fakeAddress);
+              expect(actualUpdatedOrder.customer!.shippingAddress!.city).to.equal(fakeCity);
+              expect(actualUpdatedOrder.customer!.shippingAddress!.province).to.equal(fakeProvince);
+              expect(actualUpdatedOrder.customer!.shippingAddress!.provinceCode).to.equal(fakeProvinceCode);
             });
           });
         });
@@ -717,31 +717,4 @@ describe('ChannelApe Client', () => {
       .to.be.greaterThan(expectedCreatedAt.getUTCMilliseconds());
   }
 
-  /**
-   * Generates a random number based on the provided min and max values.
-   * @param {number} min Minimum number to generate (inclusive)
-   * @param {number} max Maximum number to generate (inclusive)
-   */
-  function randomNumber(min: number, max: number): number {
-    return Math.floor(Math.random() * (max - min + 1)) + min;
-  }
-
-  /**
-   * Generates a random semi-readable word based on the provided min an max length values.
-   * @param {number} min Minium word length (inclusive)
-   * @param {number} max Maximum word length (inclusive)
-   */
-  function randomWord(min: number, max: number): string {
-    const consonantsArr = 'bcdfghjlmnpqrstv'.split('');
-    const vowelsArr = 'aeiou'.split('');
-    let word = '';
-    const length = randomNumber(min, max);
-    for (let i = 0; i < length / 2; i += 1) {
-      const randConsonant = consonantsArr[randomNumber(0, consonantsArr.length - 1)];
-      const randVowel = vowelsArr[randomNumber(0, vowelsArr.length - 1)];
-      word += (i === 0) ? randConsonant.toUpperCase() : randConsonant;
-      word += i * 2 < length - 1 ? randVowel : '';
-    }
-    return word;
-  }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.8.0",
+	"version": "1.9.0-develop.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -10,10 +10,10 @@
 			"integrity": "sha1-g8rMIUZBmLEuPMHCIErmxtev0Vg=",
 			"dev": true,
 			"requires": {
-				"@fimbul/ymir": "^0.11.0",
-				"get-caller-file": "^1.0.2",
-				"tslib": "^1.8.1",
-				"tsutils": "^2.24.0"
+				"@fimbul/ymir": "0.11.0",
+				"get-caller-file": "1.0.3",
+				"tslib": "1.9.3",
+				"tsutils": "2.29.0"
 			}
 		},
 		"@fimbul/ymir": {
@@ -22,14 +22,14 @@
 			"integrity": "sha1-iSoBmX8fgMfk5DfPXKUclZlME28=",
 			"dev": true,
 			"requires": {
-				"inversify": "^4.10.0",
-				"reflect-metadata": "^0.1.12",
-				"tslib": "^1.8.1"
+				"inversify": "4.13.0",
+				"reflect-metadata": "0.1.12",
+				"tslib": "1.9.3"
 			}
 		},
 		"@sinonjs/formatio": {
 			"version": "2.0.0",
-			"resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
 			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
 			"dev": true,
 			"requires": {
@@ -38,7 +38,7 @@
 		},
 		"@types/app-root-path": {
 			"version": "1.2.4",
-			"resolved": "http://registry.npmjs.org/@types/app-root-path/-/app-root-path-1.2.4.tgz",
+			"resolved": "https://registry.npmjs.org/@types/app-root-path/-/app-root-path-1.2.4.tgz",
 			"integrity": "sha1-p4twMoKzKsVN52j1US7MNWmRncc=",
 			"dev": true
 		},
@@ -48,7 +48,7 @@
 			"integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
 			"dev": true,
 			"requires": {
-				"axios": "*"
+				"axios": "0.18.0"
 			}
 		},
 		"@types/chai": {
@@ -84,7 +84,7 @@
 		"@types/sinon": {
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.3.3.tgz",
-			"integrity": "sha1-l8u/3cMoK1/UDHq/gLmdtCb9Qjc=",
+			"integrity": "sha512-Tt7w/ylBS/OEAlSCwzB0Db1KbxnkycP/1UkQpbvKFYoUuRn4uYsC3xh5TRPrOjTy0i8TIkSz1JdNL4GPVdf3KQ==",
 			"dev": true
 		},
 		"ansi-escapes": {
@@ -102,10 +102,10 @@
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
 			"requires": {
-				"color-convert": "^1.9.0"
+				"color-convert": "1.9.3"
 			}
 		},
 		"any-promise": {
@@ -123,10 +123,10 @@
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "~1.0.2"
+				"sprintf-js": "1.0.3"
 			}
 		},
 		"arrify": {
@@ -138,7 +138,7 @@
 		"assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
 			"dev": true
 		},
 		"axios": {
@@ -146,8 +146,8 @@
 			"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
 			"integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
 			"requires": {
-				"follow-redirects": "^1.3.0",
-				"is-buffer": "^1.1.5"
+				"follow-redirects": "1.5.8",
+				"is-buffer": "1.1.6"
 			}
 		},
 		"axios-mock-adapter": {
@@ -156,7 +156,7 @@
 			"integrity": "sha1-+8BoJdgwLJXDM00hAju6mWJV1F0=",
 			"dev": true,
 			"requires": {
-				"deep-equal": "^1.0.1"
+				"deep-equal": "1.0.1"
 			}
 		},
 		"babel-code-frame": {
@@ -165,9 +165,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -184,15 +184,15 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -201,7 +201,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"supports-color": {
@@ -215,17 +215,17 @@
 		"babel-generator": {
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-			"integrity": "sha1-GERAjTuPDTWkBOp6wYDwh6YBvZA=",
+			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"dev": true,
 			"requires": {
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"detect-indent": "^4.0.0",
-				"jsesc": "^1.3.0",
-				"lodash": "^4.17.4",
-				"source-map": "^0.5.7",
-				"trim-right": "^1.0.1"
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.11",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -242,7 +242,7 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-runtime": {
@@ -251,8 +251,8 @@
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"dev": true,
 			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
+				"core-js": "2.5.7",
+				"regenerator-runtime": "0.11.1"
 			}
 		},
 		"babel-template": {
@@ -261,11 +261,11 @@
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.11"
 			}
 		},
 		"babel-traverse": {
@@ -274,21 +274,21 @@
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.9",
+				"globals": "9.18.0",
+				"invariant": "2.2.4",
+				"lodash": "4.17.11"
 			},
 			"dependencies": {
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -302,16 +302,16 @@
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.11",
+				"to-fast-properties": "1.0.3"
 			}
 		},
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
 			"dev": true
 		},
 		"balanced-match": {
@@ -323,17 +323,17 @@
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "^1.0.0",
+				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
 		"browser-stdout": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
 		},
 		"buffer-from": {
@@ -360,12 +360,12 @@
 			"integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
 			"dev": true,
 			"requires": {
-				"assertion-error": "^1.0.1",
-				"check-error": "^1.0.1",
-				"deep-eql": "^3.0.0",
-				"get-func-name": "^2.0.0",
-				"pathval": "^1.0.0",
-				"type-detect": "^4.0.0"
+				"assertion-error": "1.1.0",
+				"check-error": "1.0.2",
+				"deep-eql": "3.0.1",
+				"get-func-name": "2.0.0",
+				"pathval": "1.1.0",
+				"type-detect": "4.0.8"
 			}
 		},
 		"chalk": {
@@ -374,9 +374,9 @@
 			"integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
+				"ansi-styles": "3.2.1",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "5.5.0"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -413,7 +413,7 @@
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "^2.0.0"
+				"restore-cursor": "2.0.0"
 			}
 		},
 		"cli-width": {
@@ -428,9 +428,9 @@
 			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 			"dev": true,
 			"requires": {
-				"string-width": "^2.1.1",
-				"strip-ansi": "^4.0.0",
-				"wrap-ansi": "^2.0.0"
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"wrap-ansi": "2.1.0"
 			}
 		},
 		"code-point-at": {
@@ -456,7 +456,7 @@
 		},
 		"commander": {
 			"version": "2.6.0",
-			"resolved": "http://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
 			"integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
 			"dev": true
 		},
@@ -472,15 +472,15 @@
 			"integrity": "sha512-/+ugz+gwFSEfTGUxn0KHkY+19XPRTXR8+7oUK/HxgiN1n7FjeJmkrbSiXAJfyQ0zORgJYPaenmymwon51YXH9Q==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.1",
+				"chalk": "2.4.1",
 				"commander": "2.6.0",
-				"date-fns": "^1.23.0",
-				"lodash": "^4.5.1",
-				"read-pkg": "^3.0.0",
+				"date-fns": "1.29.0",
+				"lodash": "4.17.11",
+				"read-pkg": "3.0.0",
 				"rx": "2.3.24",
-				"spawn-command": "^0.0.2-1",
-				"supports-color": "^3.2.3",
-				"tree-kill": "^1.1.0"
+				"spawn-command": "0.0.2-1",
+				"supports-color": "3.2.3",
+				"tree-kill": "1.2.0"
 			}
 		},
 		"core-js": {
@@ -498,14 +498,14 @@
 		"cross-spawn": {
 			"version": "6.0.5",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-			"integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 			"dev": true,
 			"requires": {
-				"nice-try": "^1.0.4",
-				"path-key": "^2.0.1",
-				"semver": "^5.5.0",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
+				"nice-try": "1.0.5",
+				"path-key": "2.0.1",
+				"semver": "5.5.1",
+				"shebang-command": "1.2.0",
+				"which": "1.3.1"
 			}
 		},
 		"date-fns": {
@@ -523,7 +523,7 @@
 		"debug": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -537,10 +537,10 @@
 		"deep-eql": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
 			"dev": true,
 			"requires": {
-				"type-detect": "^4.0.0"
+				"type-detect": "4.0.8"
 			}
 		},
 		"deep-equal": {
@@ -561,13 +561,13 @@
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"dev": true,
 			"requires": {
-				"repeating": "^2.0.0"
+				"repeating": "2.0.1"
 			}
 		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
 		},
 		"doctrine": {
@@ -576,7 +576,7 @@
 			"integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
 			"dev": true,
 			"requires": {
-				"esutils": "^1.1.6",
+				"esutils": "1.1.6",
 				"isarray": "0.0.1"
 			},
 			"dependencies": {
@@ -591,10 +591,10 @@
 		"error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-			"integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "^0.2.1"
+				"is-arrayish": "0.2.1"
 			}
 		},
 		"escape-string-regexp": {
@@ -609,11 +609,11 @@
 			"integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
 			"dev": true,
 			"requires": {
-				"esprima": "^3.1.3",
-				"estraverse": "^4.2.0",
-				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.6.1"
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"esprima": {
@@ -648,13 +648,13 @@
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -663,9 +663,9 @@
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"dev": true,
 					"requires": {
-						"lru-cache": "^4.0.1",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
+						"lru-cache": "4.1.3",
+						"shebang-command": "1.2.0",
+						"which": "1.3.1"
 					}
 				}
 			}
@@ -673,12 +673,12 @@
 		"external-editor": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-			"integrity": "sha1-BFURz9jRM/OEZnPRBHwVTiFK09U=",
+			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"dev": true,
 			"requires": {
-				"chardet": "^0.4.0",
-				"iconv-lite": "^0.4.17",
-				"tmp": "^0.0.33"
+				"chardet": "0.4.2",
+				"iconv-lite": "0.4.24",
+				"tmp": "0.0.33"
 			}
 		},
 		"faker": {
@@ -699,7 +699,7 @@
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "^1.0.5"
+				"escape-string-regexp": "1.0.5"
 			}
 		},
 		"file-url": {
@@ -714,7 +714,7 @@
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"dev": true,
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "2.0.0"
 			}
 		},
 		"follow-redirects": {
@@ -722,7 +722,7 @@
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.8.tgz",
 			"integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
 			"requires": {
-				"debug": "=3.1.0"
+				"debug": "3.1.0"
 			}
 		},
 		"fs.realpath": {
@@ -734,7 +734,7 @@
 		"get-caller-file": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-			"integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
+			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
 			"dev": true
 		},
 		"get-func-name": {
@@ -755,18 +755,18 @@
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
 			"dev": true
 		},
 		"graceful-fs": {
@@ -778,7 +778,7 @@
 		"growl": {
 			"version": "1.10.5",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
 		},
 		"has-ansi": {
@@ -787,7 +787,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -813,7 +813,7 @@
 		"hosted-git-info": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-			"integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
+			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
 			"dev": true
 		},
 		"iconv-lite": {
@@ -822,7 +822,7 @@
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"inflight": {
@@ -831,8 +831,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
 			}
 		},
 		"inherits": {
@@ -844,32 +844,32 @@
 		"inquirer": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-			"integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
+			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.0",
-				"cli-cursor": "^2.1.0",
-				"cli-width": "^2.0.0",
-				"external-editor": "^2.0.4",
-				"figures": "^2.0.0",
-				"lodash": "^4.3.0",
+				"ansi-escapes": "3.1.0",
+				"chalk": "2.4.1",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "2.2.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.11",
 				"mute-stream": "0.0.7",
-				"run-async": "^2.2.0",
-				"rx-lite": "^4.0.8",
-				"rx-lite-aggregates": "^4.0.8",
-				"string-width": "^2.1.0",
-				"strip-ansi": "^4.0.0",
-				"through": "^2.3.6"
+				"run-async": "2.3.0",
+				"rx-lite": "4.0.8",
+				"rx-lite-aggregates": "4.0.8",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
 			}
 		},
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"dev": true,
 			"requires": {
-				"loose-envify": "^1.0.0"
+				"loose-envify": "1.4.0"
 			}
 		},
 		"inversify": {
@@ -901,7 +901,7 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "^1.0.0"
+				"builtin-modules": "1.1.1"
 			}
 		},
 		"is-finite": {
@@ -910,7 +910,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -955,13 +955,13 @@
 			"integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
 			"dev": true,
 			"requires": {
-				"babel-generator": "^6.18.0",
-				"babel-template": "^6.16.0",
-				"babel-traverse": "^6.18.0",
-				"babel-types": "^6.18.0",
-				"babylon": "^6.18.0",
-				"istanbul-lib-coverage": "^1.2.1",
-				"semver": "^5.3.0"
+				"babel-generator": "6.26.1",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"istanbul-lib-coverage": "1.2.1",
+				"semver": "5.5.1"
 			}
 		},
 		"js-tokens": {
@@ -976,8 +976,8 @@
 			"integrity": "sha1-6u1lbsg0TxD1J8a/obbiJE3hZ9E=",
 			"dev": true,
 			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "1.0.10",
+				"esprima": "4.0.1"
 			},
 			"dependencies": {
 				"esprima": {
@@ -997,7 +997,7 @@
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 			"dev": true
 		},
 		"just-extend": {
@@ -1012,7 +1012,7 @@
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"dev": true,
 			"requires": {
-				"invert-kv": "^1.0.0"
+				"invert-kv": "1.0.0"
 			}
 		},
 		"levn": {
@@ -1021,8 +1021,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
 			}
 		},
 		"load-json-file": {
@@ -1031,10 +1031,10 @@
 			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^4.0.0",
-				"pify": "^3.0.0",
-				"strip-bom": "^3.0.0"
+				"graceful-fs": "4.1.11",
+				"parse-json": "4.0.0",
+				"pify": "3.0.0",
+				"strip-bom": "3.0.0"
 			}
 		},
 		"locate-path": {
@@ -1043,8 +1043,8 @@
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
 			}
 		},
 		"lodash": {
@@ -1071,15 +1071,15 @@
 			"integrity": "sha1-wh0px2BAieTyVYM+f5SzRh3h/0M=",
 			"dev": true,
 			"requires": {
-				"debug": "^2.2.0",
-				"semver": "^5.3.0",
-				"streamroller": "^0.4.0"
+				"debug": "2.6.9",
+				"semver": "5.5.1",
+				"streamroller": "0.4.1"
 			},
 			"dependencies": {
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -1096,10 +1096,10 @@
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 			"dev": true,
 			"requires": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
+				"js-tokens": "3.0.2"
 			}
 		},
 		"lru-cache": {
@@ -1108,8 +1108,8 @@
 			"integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
 			"dev": true,
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
 			}
 		},
 		"make-error": {
@@ -1124,27 +1124,27 @@
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.2.0"
 			}
 		},
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
 			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "1.1.11"
 			}
 		},
 		"minimist": {
 			"version": "0.0.8",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 			"dev": true
 		},
@@ -1160,7 +1160,7 @@
 		"mocha": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-			"integrity": "sha1-bYrlCPWRZ/lA8rWzxKYSrlDJCuY=",
+			"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
 			"dev": true,
 			"requires": {
 				"browser-stdout": "1.3.1",
@@ -1178,17 +1178,17 @@
 			"dependencies": {
 				"commander": {
 					"version": "2.15.1",
-					"resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
 					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -1196,13 +1196,13 @@
 		"mocha-typescript": {
 			"version": "1.1.17",
 			"resolved": "https://registry.npmjs.org/mocha-typescript/-/mocha-typescript-1.1.17.tgz",
-			"integrity": "sha1-94sprU+H/OjCX2V4g+Pso5+wJsk=",
+			"integrity": "sha512-Ge6pCQkZumkkhxVNdAf3JxunskShgaynCb30HYD7TT1Yhog/7NW2+6w5RcRHI+nuQrCMTX6z1+qf2pD8qwCoQA==",
 			"dev": true,
 			"requires": {
-				"@types/mocha": "^5.2.0",
-				"chalk": "^2.4.1",
-				"cross-spawn": "^6.0.5",
-				"yargs": "^11.0.0"
+				"@types/mocha": "5.2.5",
+				"chalk": "2.4.1",
+				"cross-spawn": "6.0.5",
+				"yargs": "11.1.0"
 			}
 		},
 		"ms": {
@@ -1219,12 +1219,12 @@
 		"mz": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-			"integrity": "sha1-lQCAV6Vsr63CvGPd5/n/aVWUjjI=",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
 			"dev": true,
 			"requires": {
-				"any-promise": "^1.0.0",
-				"object-assign": "^4.0.1",
-				"thenify-all": "^1.0.0"
+				"any-promise": "1.3.0",
+				"object-assign": "4.1.1",
+				"thenify-all": "1.6.0"
 			}
 		},
 		"nice-try": {
@@ -1239,11 +1239,11 @@
 			"integrity": "sha512-pxE0c9PzgrUTyhfv5p+5eMIdfU2bLEsq8VQEuE0kxM4zP7SujSar7rk9wpI2F7RyyCEvLyj5O7Is3RER5F36Fg==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "^2.0.0",
-				"just-extend": "^3.0.0",
-				"lolex": "^2.3.2",
-				"path-to-regexp": "^1.7.0",
-				"text-encoding": "^0.6.4"
+				"@sinonjs/formatio": "2.0.0",
+				"just-extend": "3.0.0",
+				"lolex": "2.7.4",
+				"path-to-regexp": "1.7.0",
+				"text-encoding": "0.6.4"
 			}
 		},
 		"normalize-package-data": {
@@ -1252,10 +1252,10 @@
 			"integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "2.7.1",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.5.1",
+				"validate-npm-package-license": "3.0.4"
 			}
 		},
 		"npm-run-path": {
@@ -1264,7 +1264,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "^2.0.0"
+				"path-key": "2.0.1"
 			}
 		},
 		"number-is-nan": {
@@ -1276,36 +1276,36 @@
 		"nyc": {
 			"version": "11.9.0",
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
-			"integrity": "sha1-QQbono++c2I6H8i27Lerqica4eQ=",
+			"integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
 			"dev": true,
 			"requires": {
-				"archy": "^1.0.0",
-				"arrify": "^1.0.1",
-				"caching-transform": "^1.0.0",
-				"convert-source-map": "^1.5.1",
-				"debug-log": "^1.0.1",
-				"default-require-extensions": "^1.0.0",
-				"find-cache-dir": "^0.1.1",
-				"find-up": "^2.1.0",
-				"foreground-child": "^1.5.3",
-				"glob": "^7.0.6",
-				"istanbul-lib-coverage": "^1.1.2",
-				"istanbul-lib-hook": "^1.1.0",
-				"istanbul-lib-instrument": "^1.10.0",
-				"istanbul-lib-report": "^1.1.3",
-				"istanbul-lib-source-maps": "^1.2.3",
-				"istanbul-reports": "^1.4.0",
-				"md5-hex": "^1.2.0",
-				"merge-source-map": "^1.1.0",
-				"micromatch": "^3.1.10",
-				"mkdirp": "^0.5.0",
-				"resolve-from": "^2.0.0",
-				"rimraf": "^2.6.2",
-				"signal-exit": "^3.0.1",
-				"spawn-wrap": "^1.4.2",
-				"test-exclude": "^4.2.0",
+				"archy": "1.0.0",
+				"arrify": "1.0.1",
+				"caching-transform": "1.0.1",
+				"convert-source-map": "1.5.1",
+				"debug-log": "1.0.1",
+				"default-require-extensions": "1.0.0",
+				"find-cache-dir": "0.1.1",
+				"find-up": "2.1.0",
+				"foreground-child": "1.5.6",
+				"glob": "7.1.2",
+				"istanbul-lib-coverage": "1.2.0",
+				"istanbul-lib-hook": "1.1.0",
+				"istanbul-lib-instrument": "1.10.1",
+				"istanbul-lib-report": "1.1.3",
+				"istanbul-lib-source-maps": "1.2.3",
+				"istanbul-reports": "1.4.0",
+				"md5-hex": "1.3.0",
+				"merge-source-map": "1.1.0",
+				"micromatch": "3.1.10",
+				"mkdirp": "0.5.1",
+				"resolve-from": "2.0.0",
+				"rimraf": "2.6.2",
+				"signal-exit": "3.0.2",
+				"spawn-wrap": "1.4.2",
+				"test-exclude": "4.2.1",
 				"yargs": "11.1.0",
-				"yargs-parser": "^8.0.0"
+				"yargs-parser": "8.1.0"
 			},
 			"dependencies": {
 				"align-text": {
@@ -1313,9 +1313,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2",
-						"longest": "^1.0.1",
-						"repeat-string": "^1.5.2"
+						"kind-of": "3.2.2",
+						"longest": "1.0.1",
+						"repeat-string": "1.6.1"
 					}
 				},
 				"amdefine": {
@@ -1338,7 +1338,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"default-require-extensions": "^1.0.0"
+						"default-require-extensions": "1.0.0"
 					}
 				},
 				"archy": {
@@ -1391,9 +1391,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"chalk": "^1.1.3",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.2"
+						"chalk": "1.1.3",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
 					}
 				},
 				"babel-generator": {
@@ -1401,14 +1401,14 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-messages": "^6.23.0",
-						"babel-runtime": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"detect-indent": "^4.0.0",
-						"jsesc": "^1.3.0",
-						"lodash": "^4.17.4",
-						"source-map": "^0.5.7",
-						"trim-right": "^1.0.1"
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"detect-indent": "4.0.0",
+						"jsesc": "1.3.0",
+						"lodash": "4.17.10",
+						"source-map": "0.5.7",
+						"trim-right": "1.0.1"
 					}
 				},
 				"babel-messages": {
@@ -1416,7 +1416,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-runtime": "^6.22.0"
+						"babel-runtime": "6.26.0"
 					}
 				},
 				"babel-runtime": {
@@ -1424,8 +1424,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"core-js": "^2.4.0",
-						"regenerator-runtime": "^0.11.0"
+						"core-js": "2.5.6",
+						"regenerator-runtime": "0.11.1"
 					}
 				},
 				"babel-template": {
@@ -1433,11 +1433,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-runtime": "^6.26.0",
-						"babel-traverse": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"babylon": "^6.18.0",
-						"lodash": "^4.17.4"
+						"babel-runtime": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"lodash": "4.17.10"
 					}
 				},
 				"babel-traverse": {
@@ -1445,15 +1445,15 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-code-frame": "^6.26.0",
-						"babel-messages": "^6.23.0",
-						"babel-runtime": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"babylon": "^6.18.0",
-						"debug": "^2.6.8",
-						"globals": "^9.18.0",
-						"invariant": "^2.2.2",
-						"lodash": "^4.17.4"
+						"babel-code-frame": "6.26.0",
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"debug": "2.6.9",
+						"globals": "9.18.0",
+						"invariant": "2.2.4",
+						"lodash": "4.17.10"
 					}
 				},
 				"babel-types": {
@@ -1461,10 +1461,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-runtime": "^6.26.0",
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.4",
-						"to-fast-properties": "^1.0.3"
+						"babel-runtime": "6.26.0",
+						"esutils": "2.0.2",
+						"lodash": "4.17.10",
+						"to-fast-properties": "1.0.3"
 					}
 				},
 				"babylon": {
@@ -1482,13 +1482,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cache-base": "^1.0.1",
-						"class-utils": "^0.3.5",
-						"component-emitter": "^1.2.1",
-						"define-property": "^1.0.0",
-						"isobject": "^3.0.1",
-						"mixin-deep": "^1.2.0",
-						"pascalcase": "^0.1.1"
+						"cache-base": "1.0.1",
+						"class-utils": "0.3.6",
+						"component-emitter": "1.2.1",
+						"define-property": "1.0.0",
+						"isobject": "3.0.1",
+						"mixin-deep": "1.3.1",
+						"pascalcase": "0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1496,7 +1496,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -1504,7 +1504,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-data-descriptor": {
@@ -1512,7 +1512,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-descriptor": {
@@ -1520,9 +1520,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
+								"is-accessor-descriptor": "1.0.0",
+								"is-data-descriptor": "1.0.0",
+								"kind-of": "6.0.2"
 							}
 						},
 						"isobject": {
@@ -1542,7 +1542,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"balanced-match": "^1.0.0",
+						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -1551,16 +1551,16 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -1568,7 +1568,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -1583,15 +1583,15 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"collection-visit": "^1.0.0",
-						"component-emitter": "^1.2.1",
-						"get-value": "^2.0.6",
-						"has-value": "^1.0.0",
-						"isobject": "^3.0.1",
-						"set-value": "^2.0.0",
-						"to-object-path": "^0.3.0",
-						"union-value": "^1.0.0",
-						"unset-value": "^1.0.0"
+						"collection-visit": "1.0.0",
+						"component-emitter": "1.2.1",
+						"get-value": "2.0.6",
+						"has-value": "1.0.0",
+						"isobject": "3.0.1",
+						"set-value": "2.0.0",
+						"to-object-path": "0.3.0",
+						"union-value": "1.0.0",
+						"unset-value": "1.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1606,9 +1606,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"md5-hex": "^1.2.0",
-						"mkdirp": "^0.5.1",
-						"write-file-atomic": "^1.1.4"
+						"md5-hex": "1.3.0",
+						"mkdirp": "0.5.1",
+						"write-file-atomic": "1.3.4"
 					}
 				},
 				"camelcase": {
@@ -1623,8 +1623,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "^0.1.3",
-						"lazy-cache": "^1.0.3"
+						"align-text": "0.1.4",
+						"lazy-cache": "1.0.4"
 					}
 				},
 				"chalk": {
@@ -1632,11 +1632,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					}
 				},
 				"class-utils": {
@@ -1644,10 +1644,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arr-union": "^3.1.0",
-						"define-property": "^0.2.5",
-						"isobject": "^3.0.0",
-						"static-extend": "^0.1.1"
+						"arr-union": "3.1.0",
+						"define-property": "0.2.5",
+						"isobject": "3.0.1",
+						"static-extend": "0.1.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1655,7 +1655,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						},
 						"isobject": {
@@ -1671,8 +1671,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"center-align": "^0.1.1",
-						"right-align": "^0.1.1",
+						"center-align": "0.1.3",
+						"right-align": "0.1.3",
 						"wordwrap": "0.0.2"
 					},
 					"dependencies": {
@@ -1694,8 +1694,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"map-visit": "^1.0.0",
-						"object-visit": "^1.0.0"
+						"map-visit": "1.0.0",
+						"object-visit": "1.0.1"
 					}
 				},
 				"commondir": {
@@ -1733,8 +1733,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"lru-cache": "^4.0.1",
-						"which": "^1.2.9"
+						"lru-cache": "4.1.3",
+						"which": "1.3.0"
 					}
 				},
 				"debug": {
@@ -1765,7 +1765,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"strip-bom": "^2.0.0"
+						"strip-bom": "2.0.0"
 					}
 				},
 				"define-property": {
@@ -1773,8 +1773,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.2",
-						"isobject": "^3.0.1"
+						"is-descriptor": "1.0.2",
+						"isobject": "3.0.1"
 					},
 					"dependencies": {
 						"is-accessor-descriptor": {
@@ -1782,7 +1782,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-data-descriptor": {
@@ -1790,7 +1790,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-descriptor": {
@@ -1798,9 +1798,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
+								"is-accessor-descriptor": "1.0.0",
+								"is-data-descriptor": "1.0.0",
+								"kind-of": "6.0.2"
 							}
 						},
 						"isobject": {
@@ -1820,7 +1820,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"repeating": "^2.0.0"
+						"repeating": "2.0.1"
 					}
 				},
 				"error-ex": {
@@ -1828,7 +1828,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-arrayish": "^0.2.1"
+						"is-arrayish": "0.2.1"
 					}
 				},
 				"escape-string-regexp": {
@@ -1846,13 +1846,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
 					},
 					"dependencies": {
 						"cross-spawn": {
@@ -1860,9 +1860,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"lru-cache": "^4.0.1",
-								"shebang-command": "^1.2.0",
-								"which": "^1.2.9"
+								"lru-cache": "4.1.3",
+								"shebang-command": "1.2.0",
+								"which": "1.3.0"
 							}
 						}
 					}
@@ -1872,13 +1872,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1886,7 +1886,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						},
 						"extend-shallow": {
@@ -1894,7 +1894,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -1904,8 +1904,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"assign-symbols": "^1.0.0",
-						"is-extendable": "^1.0.1"
+						"assign-symbols": "1.0.0",
+						"is-extendable": "1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
@@ -1913,7 +1913,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-plain-object": "^2.0.4"
+								"is-plain-object": "2.0.4"
 							}
 						}
 					}
@@ -1923,14 +1923,14 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1938,7 +1938,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"extend-shallow": {
@@ -1946,7 +1946,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -1954,7 +1954,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-data-descriptor": {
@@ -1962,7 +1962,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-descriptor": {
@@ -1970,9 +1970,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
+								"is-accessor-descriptor": "1.0.0",
+								"is-data-descriptor": "1.0.0",
+								"kind-of": "6.0.2"
 							}
 						},
 						"kind-of": {
@@ -1987,10 +1987,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -1998,7 +1998,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -2008,9 +2008,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"commondir": "^1.0.1",
-						"mkdirp": "^0.5.1",
-						"pkg-dir": "^1.0.0"
+						"commondir": "1.0.1",
+						"mkdirp": "0.5.1",
+						"pkg-dir": "1.0.0"
 					}
 				},
 				"find-up": {
@@ -2018,7 +2018,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "2.0.0"
 					}
 				},
 				"for-in": {
@@ -2031,8 +2031,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^4",
-						"signal-exit": "^3.0.0"
+						"cross-spawn": "4.0.2",
+						"signal-exit": "3.0.2"
 					}
 				},
 				"fragment-cache": {
@@ -2040,7 +2040,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"map-cache": "^0.2.2"
+						"map-cache": "0.2.2"
 					}
 				},
 				"fs.realpath": {
@@ -2068,12 +2068,12 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"globals": {
@@ -2091,10 +2091,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"async": "^1.4.0",
-						"optimist": "^0.6.1",
-						"source-map": "^0.4.4",
-						"uglify-js": "^2.6"
+						"async": "1.5.2",
+						"optimist": "0.6.1",
+						"source-map": "0.4.4",
+						"uglify-js": "2.8.29"
 					},
 					"dependencies": {
 						"source-map": {
@@ -2102,7 +2102,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"amdefine": ">=0.0.4"
+								"amdefine": "1.0.1"
 							}
 						}
 					}
@@ -2112,7 +2112,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"has-flag": {
@@ -2125,9 +2125,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"get-value": "^2.0.6",
-						"has-values": "^1.0.0",
-						"isobject": "^3.0.0"
+						"get-value": "2.0.6",
+						"has-values": "1.0.0",
+						"isobject": "3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -2142,8 +2142,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-number": "^3.0.0",
-						"kind-of": "^4.0.0"
+						"is-number": "3.0.0",
+						"kind-of": "4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
@@ -2151,7 +2151,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -2159,7 +2159,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.6"
 									}
 								}
 							}
@@ -2169,7 +2169,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -2189,8 +2189,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
 					}
 				},
 				"inherits": {
@@ -2203,7 +2203,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"loose-envify": "^1.0.0"
+						"loose-envify": "1.3.1"
 					}
 				},
 				"invert-kv": {
@@ -2216,7 +2216,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"is-arrayish": {
@@ -2234,7 +2234,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"builtin-modules": "^1.0.0"
+						"builtin-modules": "1.1.1"
 					}
 				},
 				"is-data-descriptor": {
@@ -2242,7 +2242,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"is-descriptor": {
@@ -2250,9 +2250,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^0.1.6",
-						"is-data-descriptor": "^0.1.4",
-						"kind-of": "^5.0.0"
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2272,7 +2272,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -2285,7 +2285,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"is-odd": {
@@ -2293,7 +2293,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-number": "^4.0.0"
+						"is-number": "4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
@@ -2308,7 +2308,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"isobject": "^3.0.1"
+						"isobject": "3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -2358,7 +2358,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"append-transform": "^0.4.0"
+						"append-transform": "0.4.0"
 					}
 				},
 				"istanbul-lib-instrument": {
@@ -2366,13 +2366,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-generator": "^6.18.0",
-						"babel-template": "^6.16.0",
-						"babel-traverse": "^6.18.0",
-						"babel-types": "^6.18.0",
-						"babylon": "^6.18.0",
-						"istanbul-lib-coverage": "^1.2.0",
-						"semver": "^5.3.0"
+						"babel-generator": "6.26.1",
+						"babel-template": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"istanbul-lib-coverage": "1.2.0",
+						"semver": "5.5.0"
 					}
 				},
 				"istanbul-lib-report": {
@@ -2380,10 +2380,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"istanbul-lib-coverage": "^1.1.2",
-						"mkdirp": "^0.5.1",
-						"path-parse": "^1.0.5",
-						"supports-color": "^3.1.2"
+						"istanbul-lib-coverage": "1.2.0",
+						"mkdirp": "0.5.1",
+						"path-parse": "1.0.5",
+						"supports-color": "3.2.3"
 					},
 					"dependencies": {
 						"supports-color": {
@@ -2391,7 +2391,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"has-flag": "^1.0.0"
+								"has-flag": "1.0.0"
 							}
 						}
 					}
@@ -2401,11 +2401,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"debug": "^3.1.0",
-						"istanbul-lib-coverage": "^1.1.2",
-						"mkdirp": "^0.5.1",
-						"rimraf": "^2.6.1",
-						"source-map": "^0.5.3"
+						"debug": "3.1.0",
+						"istanbul-lib-coverage": "1.2.0",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.2",
+						"source-map": "0.5.7"
 					},
 					"dependencies": {
 						"debug": {
@@ -2423,7 +2423,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"handlebars": "^4.0.3"
+						"handlebars": "4.0.11"
 					}
 				},
 				"js-tokens": {
@@ -2441,7 +2441,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"lazy-cache": {
@@ -2455,7 +2455,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"invert-kv": "^1.0.0"
+						"invert-kv": "1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -2463,11 +2463,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
 					}
 				},
 				"locate-path": {
@@ -2475,8 +2475,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
+						"p-locate": "2.0.0",
+						"path-exists": "3.0.0"
 					},
 					"dependencies": {
 						"path-exists": {
@@ -2501,7 +2501,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"js-tokens": "^3.0.0"
+						"js-tokens": "3.0.2"
 					}
 				},
 				"lru-cache": {
@@ -2509,8 +2509,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
+						"pseudomap": "1.0.2",
+						"yallist": "2.1.2"
 					}
 				},
 				"map-cache": {
@@ -2523,7 +2523,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"object-visit": "^1.0.0"
+						"object-visit": "1.0.1"
 					}
 				},
 				"md5-hex": {
@@ -2531,7 +2531,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"md5-o-matic": "^0.1.1"
+						"md5-o-matic": "0.1.1"
 					}
 				},
 				"md5-o-matic": {
@@ -2544,7 +2544,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"mimic-fn": "^1.0.0"
+						"mimic-fn": "1.2.0"
 					}
 				},
 				"merge-source-map": {
@@ -2552,7 +2552,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"source-map": "^0.6.1"
+						"source-map": "0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
@@ -2567,19 +2567,19 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2599,7 +2599,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"brace-expansion": "^1.1.7"
+						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
@@ -2612,8 +2612,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"for-in": "^1.0.2",
-						"is-extendable": "^1.0.1"
+						"for-in": "1.0.2",
+						"is-extendable": "1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
@@ -2621,7 +2621,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-plain-object": "^2.0.4"
+								"is-plain-object": "2.0.4"
 							}
 						}
 					}
@@ -2644,18 +2644,18 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"fragment-cache": "^0.2.1",
-						"is-odd": "^2.0.0",
-						"is-windows": "^1.0.2",
-						"kind-of": "^6.0.2",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"fragment-cache": "0.2.1",
+						"is-odd": "2.0.0",
+						"is-windows": "1.0.2",
+						"kind-of": "6.0.2",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -2680,10 +2680,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "^2.1.4",
-						"is-builtin-module": "^1.0.0",
-						"semver": "2 || 3 || 4 || 5",
-						"validate-npm-package-license": "^3.0.1"
+						"hosted-git-info": "2.6.0",
+						"is-builtin-module": "1.0.0",
+						"semver": "5.5.0",
+						"validate-npm-package-license": "3.0.3"
 					}
 				},
 				"npm-run-path": {
@@ -2691,7 +2691,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"path-key": "^2.0.0"
+						"path-key": "2.0.1"
 					}
 				},
 				"number-is-nan": {
@@ -2709,9 +2709,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"copy-descriptor": "^0.1.0",
-						"define-property": "^0.2.5",
-						"kind-of": "^3.0.3"
+						"copy-descriptor": "0.1.1",
+						"define-property": "0.2.5",
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -2719,7 +2719,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						}
 					}
@@ -2729,7 +2729,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"isobject": "^3.0.0"
+						"isobject": "3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -2744,7 +2744,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"isobject": "^3.0.1"
+						"isobject": "3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -2759,7 +2759,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"wrappy": "1"
+						"wrappy": "1.0.2"
 					}
 				},
 				"optimist": {
@@ -2767,8 +2767,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"minimist": "~0.0.1",
-						"wordwrap": "~0.0.2"
+						"minimist": "0.0.8",
+						"wordwrap": "0.0.3"
 					}
 				},
 				"os-homedir": {
@@ -2781,9 +2781,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"execa": "^0.7.0",
-						"lcid": "^1.0.0",
-						"mem": "^1.1.0"
+						"execa": "0.7.0",
+						"lcid": "1.0.0",
+						"mem": "1.1.0"
 					}
 				},
 				"p-finally": {
@@ -2796,7 +2796,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-try": "^1.0.0"
+						"p-try": "1.0.0"
 					}
 				},
 				"p-locate": {
@@ -2804,7 +2804,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-limit": "^1.1.0"
+						"p-limit": "1.2.0"
 					}
 				},
 				"p-try": {
@@ -2817,7 +2817,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.2.0"
+						"error-ex": "1.3.1"
 					}
 				},
 				"pascalcase": {
@@ -2830,7 +2830,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-is-absolute": {
@@ -2853,9 +2853,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"pify": {
@@ -2873,7 +2873,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pinkie": "^2.0.0"
+						"pinkie": "2.0.4"
 					}
 				},
 				"pkg-dir": {
@@ -2881,7 +2881,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"find-up": "^1.0.0"
+						"find-up": "1.1.2"
 					},
 					"dependencies": {
 						"find-up": {
@@ -2889,8 +2889,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"path-exists": "^2.0.0",
-								"pinkie-promise": "^2.0.0"
+								"path-exists": "2.1.0",
+								"pinkie-promise": "2.0.1"
 							}
 						}
 					}
@@ -2910,9 +2910,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
 					}
 				},
 				"read-pkg-up": {
@@ -2920,8 +2920,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
 					},
 					"dependencies": {
 						"find-up": {
@@ -2929,8 +2929,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"path-exists": "^2.0.0",
-								"pinkie-promise": "^2.0.0"
+								"path-exists": "2.1.0",
+								"pinkie-promise": "2.0.1"
 							}
 						}
 					}
@@ -2945,8 +2945,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^3.0.2",
-						"safe-regex": "^1.1.0"
+						"extend-shallow": "3.0.2",
+						"safe-regex": "1.1.0"
 					}
 				},
 				"repeat-element": {
@@ -2964,7 +2964,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-finite": "^1.0.0"
+						"is-finite": "1.0.2"
 					}
 				},
 				"require-directory": {
@@ -2998,7 +2998,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "^0.1.1"
+						"align-text": "0.1.4"
 					}
 				},
 				"rimraf": {
@@ -3006,7 +3006,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "7.1.2"
 					}
 				},
 				"safe-regex": {
@@ -3014,7 +3014,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ret": "~0.1.10"
+						"ret": "0.1.15"
 					}
 				},
 				"semver": {
@@ -3032,10 +3032,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.3",
-						"split-string": "^3.0.1"
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"split-string": "3.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -3043,7 +3043,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -3053,7 +3053,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"shebang-regex": "^1.0.0"
+						"shebang-regex": "1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -3076,14 +3076,14 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"base": "^0.11.1",
-						"debug": "^2.2.0",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"map-cache": "^0.2.2",
-						"source-map": "^0.5.6",
-						"source-map-resolve": "^0.5.0",
-						"use": "^3.1.0"
+						"base": "0.11.2",
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"map-cache": "0.2.2",
+						"source-map": "0.5.7",
+						"source-map-resolve": "0.5.1",
+						"use": "3.1.0"
 					},
 					"dependencies": {
 						"define-property": {
@@ -3091,7 +3091,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						},
 						"extend-shallow": {
@@ -3099,7 +3099,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -3109,9 +3109,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"define-property": "^1.0.0",
-						"isobject": "^3.0.0",
-						"snapdragon-util": "^3.0.1"
+						"define-property": "1.0.0",
+						"isobject": "3.0.1",
+						"snapdragon-util": "3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -3119,7 +3119,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -3127,7 +3127,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-data-descriptor": {
@@ -3135,7 +3135,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-descriptor": {
@@ -3143,9 +3143,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
+								"is-accessor-descriptor": "1.0.0",
+								"is-data-descriptor": "1.0.0",
+								"kind-of": "6.0.2"
 							}
 						},
 						"isobject": {
@@ -3165,7 +3165,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.2.0"
+						"kind-of": "3.2.2"
 					}
 				},
 				"source-map": {
@@ -3178,11 +3178,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"atob": "^2.0.0",
-						"decode-uri-component": "^0.2.0",
-						"resolve-url": "^0.2.1",
-						"source-map-url": "^0.4.0",
-						"urix": "^0.1.0"
+						"atob": "2.1.1",
+						"decode-uri-component": "0.2.0",
+						"resolve-url": "0.2.1",
+						"source-map-url": "0.4.0",
+						"urix": "0.1.0"
 					}
 				},
 				"source-map-url": {
@@ -3195,12 +3195,12 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"foreground-child": "^1.5.6",
-						"mkdirp": "^0.5.0",
-						"os-homedir": "^1.0.1",
-						"rimraf": "^2.6.2",
-						"signal-exit": "^3.0.2",
-						"which": "^1.3.0"
+						"foreground-child": "1.5.6",
+						"mkdirp": "0.5.1",
+						"os-homedir": "1.0.2",
+						"rimraf": "2.6.2",
+						"signal-exit": "3.0.2",
+						"which": "1.3.0"
 					}
 				},
 				"spdx-correct": {
@@ -3208,8 +3208,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-expression-parse": "^3.0.0",
-						"spdx-license-ids": "^3.0.0"
+						"spdx-expression-parse": "3.0.0",
+						"spdx-license-ids": "3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -3222,8 +3222,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-exceptions": "^2.1.0",
-						"spdx-license-ids": "^3.0.0"
+						"spdx-exceptions": "2.1.0",
+						"spdx-license-ids": "3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -3236,7 +3236,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^3.0.0"
+						"extend-shallow": "3.0.2"
 					}
 				},
 				"static-extend": {
@@ -3244,8 +3244,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"define-property": "^0.2.5",
-						"object-copy": "^0.1.0"
+						"define-property": "0.2.5",
+						"object-copy": "0.1.0"
 					},
 					"dependencies": {
 						"define-property": {
@@ -3253,7 +3253,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						}
 					}
@@ -3263,8 +3263,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -3277,7 +3277,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^3.0.0"
+								"ansi-regex": "3.0.0"
 							}
 						}
 					}
@@ -3287,7 +3287,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"strip-bom": {
@@ -3295,7 +3295,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-utf8": "^0.2.0"
+						"is-utf8": "0.2.1"
 					}
 				},
 				"strip-eof": {
@@ -3313,11 +3313,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arrify": "^1.0.1",
-						"micromatch": "^3.1.8",
-						"object-assign": "^4.1.0",
-						"read-pkg-up": "^1.0.1",
-						"require-main-filename": "^1.0.1"
+						"arrify": "1.0.1",
+						"micromatch": "3.1.10",
+						"object-assign": "4.1.1",
+						"read-pkg-up": "1.0.1",
+						"require-main-filename": "1.0.1"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -3335,16 +3335,16 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arr-flatten": "^1.1.0",
-								"array-unique": "^0.3.2",
-								"extend-shallow": "^2.0.1",
-								"fill-range": "^4.0.0",
-								"isobject": "^3.0.1",
-								"repeat-element": "^1.1.2",
-								"snapdragon": "^0.8.1",
-								"snapdragon-node": "^2.0.1",
-								"split-string": "^3.0.2",
-								"to-regex": "^3.0.1"
+								"arr-flatten": "1.1.0",
+								"array-unique": "0.3.2",
+								"extend-shallow": "2.0.1",
+								"fill-range": "4.0.0",
+								"isobject": "3.0.1",
+								"repeat-element": "1.1.2",
+								"snapdragon": "0.8.2",
+								"snapdragon-node": "2.1.1",
+								"split-string": "3.1.0",
+								"to-regex": "3.0.2"
 							},
 							"dependencies": {
 								"extend-shallow": {
@@ -3352,7 +3352,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "^0.1.0"
+										"is-extendable": "0.1.1"
 									}
 								}
 							}
@@ -3362,13 +3362,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"debug": "^2.3.3",
-								"define-property": "^0.2.5",
-								"extend-shallow": "^2.0.1",
-								"posix-character-classes": "^0.1.0",
-								"regex-not": "^1.0.0",
-								"snapdragon": "^0.8.1",
-								"to-regex": "^3.0.1"
+								"debug": "2.6.9",
+								"define-property": "0.2.5",
+								"extend-shallow": "2.0.1",
+								"posix-character-classes": "0.1.1",
+								"regex-not": "1.0.2",
+								"snapdragon": "0.8.2",
+								"to-regex": "3.0.2"
 							},
 							"dependencies": {
 								"define-property": {
@@ -3376,7 +3376,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "^0.1.0"
+										"is-descriptor": "0.1.6"
 									}
 								},
 								"extend-shallow": {
@@ -3384,7 +3384,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "^0.1.0"
+										"is-extendable": "0.1.1"
 									}
 								},
 								"is-accessor-descriptor": {
@@ -3392,7 +3392,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "^3.0.2"
+										"kind-of": "3.2.2"
 									},
 									"dependencies": {
 										"kind-of": {
@@ -3400,7 +3400,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-buffer": "^1.1.5"
+												"is-buffer": "1.1.6"
 											}
 										}
 									}
@@ -3410,7 +3410,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "^3.0.2"
+										"kind-of": "3.2.2"
 									},
 									"dependencies": {
 										"kind-of": {
@@ -3418,7 +3418,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-buffer": "^1.1.5"
+												"is-buffer": "1.1.6"
 											}
 										}
 									}
@@ -3428,9 +3428,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-accessor-descriptor": "^0.1.6",
-										"is-data-descriptor": "^0.1.4",
-										"kind-of": "^5.0.0"
+										"is-accessor-descriptor": "0.1.6",
+										"is-data-descriptor": "0.1.4",
+										"kind-of": "5.1.0"
 									}
 								},
 								"kind-of": {
@@ -3445,14 +3445,14 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"array-unique": "^0.3.2",
-								"define-property": "^1.0.0",
-								"expand-brackets": "^2.1.4",
-								"extend-shallow": "^2.0.1",
-								"fragment-cache": "^0.2.1",
-								"regex-not": "^1.0.0",
-								"snapdragon": "^0.8.1",
-								"to-regex": "^3.0.1"
+								"array-unique": "0.3.2",
+								"define-property": "1.0.0",
+								"expand-brackets": "2.1.4",
+								"extend-shallow": "2.0.1",
+								"fragment-cache": "0.2.1",
+								"regex-not": "1.0.2",
+								"snapdragon": "0.8.2",
+								"to-regex": "3.0.2"
 							},
 							"dependencies": {
 								"define-property": {
@@ -3460,7 +3460,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "^1.0.0"
+										"is-descriptor": "1.0.2"
 									}
 								},
 								"extend-shallow": {
@@ -3468,7 +3468,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "^0.1.0"
+										"is-extendable": "0.1.1"
 									}
 								}
 							}
@@ -3478,10 +3478,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"extend-shallow": "^2.0.1",
-								"is-number": "^3.0.0",
-								"repeat-string": "^1.6.1",
-								"to-regex-range": "^2.1.0"
+								"extend-shallow": "2.0.1",
+								"is-number": "3.0.0",
+								"repeat-string": "1.6.1",
+								"to-regex-range": "2.1.1"
 							},
 							"dependencies": {
 								"extend-shallow": {
@@ -3489,7 +3489,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "^0.1.0"
+										"is-extendable": "0.1.1"
 									}
 								}
 							}
@@ -3499,7 +3499,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-data-descriptor": {
@@ -3507,7 +3507,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-descriptor": {
@@ -3515,9 +3515,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
+								"is-accessor-descriptor": "1.0.0",
+								"is-data-descriptor": "1.0.0",
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-number": {
@@ -3525,7 +3525,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -3533,7 +3533,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.6"
 									}
 								}
 							}
@@ -3553,19 +3553,19 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arr-diff": "^4.0.0",
-								"array-unique": "^0.3.2",
-								"braces": "^2.3.1",
-								"define-property": "^2.0.2",
-								"extend-shallow": "^3.0.2",
-								"extglob": "^2.0.4",
-								"fragment-cache": "^0.2.1",
-								"kind-of": "^6.0.2",
-								"nanomatch": "^1.2.9",
-								"object.pick": "^1.3.0",
-								"regex-not": "^1.0.0",
-								"snapdragon": "^0.8.1",
-								"to-regex": "^3.0.2"
+								"arr-diff": "4.0.0",
+								"array-unique": "0.3.2",
+								"braces": "2.3.2",
+								"define-property": "2.0.2",
+								"extend-shallow": "3.0.2",
+								"extglob": "2.0.4",
+								"fragment-cache": "0.2.1",
+								"kind-of": "6.0.2",
+								"nanomatch": "1.2.9",
+								"object.pick": "1.3.0",
+								"regex-not": "1.0.2",
+								"snapdragon": "0.8.2",
+								"to-regex": "3.0.2"
 							}
 						}
 					}
@@ -3580,7 +3580,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"to-regex": {
@@ -3588,10 +3588,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"regex-not": "^1.0.2",
-						"safe-regex": "^1.1.0"
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"regex-not": "1.0.2",
+						"safe-regex": "1.1.0"
 					}
 				},
 				"to-regex-range": {
@@ -3599,8 +3599,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
 					},
 					"dependencies": {
 						"is-number": {
@@ -3608,7 +3608,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							}
 						}
 					}
@@ -3624,9 +3624,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"source-map": "~0.5.1",
-						"uglify-to-browserify": "~1.0.0",
-						"yargs": "~3.10.0"
+						"source-map": "0.5.7",
+						"uglify-to-browserify": "1.0.2",
+						"yargs": "3.10.0"
 					},
 					"dependencies": {
 						"yargs": {
@@ -3635,9 +3635,9 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"camelcase": "^1.0.2",
-								"cliui": "^2.1.0",
-								"decamelize": "^1.0.0",
+								"camelcase": "1.2.1",
+								"cliui": "2.1.0",
+								"decamelize": "1.2.0",
 								"window-size": "0.1.0"
 							}
 						}
@@ -3654,10 +3654,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arr-union": "^3.1.0",
-						"get-value": "^2.0.6",
-						"is-extendable": "^0.1.1",
-						"set-value": "^0.4.3"
+						"arr-union": "3.1.0",
+						"get-value": "2.0.6",
+						"is-extendable": "0.1.1",
+						"set-value": "0.4.3"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -3665,7 +3665,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						},
 						"set-value": {
@@ -3673,10 +3673,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"extend-shallow": "^2.0.1",
-								"is-extendable": "^0.1.1",
-								"is-plain-object": "^2.0.1",
-								"to-object-path": "^0.3.0"
+								"extend-shallow": "2.0.1",
+								"is-extendable": "0.1.1",
+								"is-plain-object": "2.0.4",
+								"to-object-path": "0.3.0"
 							}
 						}
 					}
@@ -3686,8 +3686,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"has-value": "^0.3.1",
-						"isobject": "^3.0.0"
+						"has-value": "0.3.1",
+						"isobject": "3.0.1"
 					},
 					"dependencies": {
 						"has-value": {
@@ -3695,9 +3695,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"get-value": "^2.0.3",
-								"has-values": "^0.1.4",
-								"isobject": "^2.0.0"
+								"get-value": "2.0.6",
+								"has-values": "0.1.4",
+								"isobject": "2.1.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -3732,7 +3732,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.2"
+						"kind-of": "6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -3747,8 +3747,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-correct": "^3.0.0",
-						"spdx-expression-parse": "^3.0.0"
+						"spdx-correct": "3.0.0",
+						"spdx-expression-parse": "3.0.0"
 					}
 				},
 				"which": {
@@ -3756,7 +3756,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"isexe": "^2.0.0"
+						"isexe": "2.0.0"
 					}
 				},
 				"which-module": {
@@ -3780,8 +3780,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1"
 					},
 					"dependencies": {
 						"is-fullwidth-code-point": {
@@ -3789,7 +3789,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"number-is-nan": "^1.0.0"
+								"number-is-nan": "1.0.1"
 							}
 						},
 						"string-width": {
@@ -3797,9 +3797,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
 							}
 						}
 					}
@@ -3814,9 +3814,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.11",
-						"imurmurhash": "^0.1.4",
-						"slide": "^1.1.5"
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
 					}
 				},
 				"y18n": {
@@ -3834,18 +3834,18 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^9.0.2"
+						"cliui": "4.1.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "9.0.2"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -3863,9 +3863,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"string-width": "^2.1.1",
-								"strip-ansi": "^4.0.0",
-								"wrap-ansi": "^2.0.0"
+								"string-width": "2.1.1",
+								"strip-ansi": "4.0.0",
+								"wrap-ansi": "2.1.0"
 							}
 						},
 						"strip-ansi": {
@@ -3873,7 +3873,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^3.0.0"
+								"ansi-regex": "3.0.0"
 							}
 						},
 						"yargs-parser": {
@@ -3881,7 +3881,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"camelcase": "^4.1.0"
+								"camelcase": "4.1.0"
 							}
 						}
 					}
@@ -3891,7 +3891,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -3915,7 +3915,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1"
+				"wrappy": "1.0.2"
 			}
 		},
 		"onetime": {
@@ -3924,7 +3924,7 @@
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.2.0"
 			}
 		},
 		"optionator": {
@@ -3933,23 +3933,23 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
 			}
 		},
 		"os-locale": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-			"integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
+			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"dev": true,
 			"requires": {
-				"execa": "^0.7.0",
-				"lcid": "^1.0.0",
-				"mem": "^1.1.0"
+				"execa": "0.7.0",
+				"lcid": "1.0.0",
+				"mem": "1.1.0"
 			}
 		},
 		"os-tmpdir": {
@@ -3967,10 +3967,10 @@
 		"p-limit": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 			"dev": true,
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "1.0.0"
 			}
 		},
 		"p-locate": {
@@ -3979,7 +3979,7 @@
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "1.3.0"
 			}
 		},
 		"p-try": {
@@ -3994,8 +3994,8 @@
 			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.3.1",
-				"json-parse-better-errors": "^1.0.1"
+				"error-ex": "1.3.2",
+				"json-parse-better-errors": "1.0.2"
 			}
 		},
 		"path-exists": {
@@ -4034,10 +4034,10 @@
 		"path-type": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-			"integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"dev": true,
 			"requires": {
-				"pify": "^3.0.0"
+				"pify": "3.0.0"
 			}
 		},
 		"pathval": {
@@ -4087,9 +4087,9 @@
 			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^4.0.0",
-				"normalize-package-data": "^2.3.2",
-				"path-type": "^3.0.0"
+				"load-json-file": "4.0.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "3.0.0"
 			}
 		},
 		"readable-stream": {
@@ -4098,10 +4098,10 @@
 			"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
 			"dev": true,
 			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.1",
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
 				"isarray": "0.0.1",
-				"string_decoder": "~0.10.x"
+				"string_decoder": "0.10.31"
 			}
 		},
 		"reflect-metadata": {
@@ -4113,7 +4113,7 @@
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
 			"dev": true
 		},
 		"repeating": {
@@ -4122,7 +4122,7 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "^1.0.0"
+				"is-finite": "1.0.2"
 			}
 		},
 		"require-directory": {
@@ -4143,7 +4143,7 @@
 			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
 			"dev": true,
 			"requires": {
-				"path-parse": "^1.0.5"
+				"path-parse": "1.0.6"
 			}
 		},
 		"restore-cursor": {
@@ -4152,8 +4152,8 @@
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"dev": true,
 			"requires": {
-				"onetime": "^2.0.0",
-				"signal-exit": "^3.0.2"
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"rimraf": {
@@ -4162,7 +4162,7 @@
 			"integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "7.1.2"
 			}
 		},
 		"run-async": {
@@ -4171,7 +4171,7 @@
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"dev": true,
 			"requires": {
-				"is-promise": "^2.1.0"
+				"is-promise": "2.1.0"
 			}
 		},
 		"rx": {
@@ -4192,7 +4192,7 @@
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 			"dev": true,
 			"requires": {
-				"rx-lite": "*"
+				"rx-lite": "4.0.8"
 			}
 		},
 		"rxjs": {
@@ -4207,13 +4207,13 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
 		"samsam": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-			"integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
+			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
 			"dev": true
 		},
 		"semver": {
@@ -4240,7 +4240,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "^1.0.0"
+				"shebang-regex": "1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -4258,16 +4258,16 @@
 		"sinon": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
-			"integrity": "sha1-QnrjEqM308UWgEzidU6MDVAoywQ=",
+			"integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "^2.0.0",
-				"diff": "^3.1.0",
-				"lodash.get": "^4.4.2",
-				"lolex": "^2.2.0",
-				"nise": "^1.2.0",
-				"supports-color": "^5.1.0",
-				"type-detect": "^4.0.5"
+				"@sinonjs/formatio": "2.0.0",
+				"diff": "3.5.0",
+				"lodash.get": "4.4.2",
+				"lolex": "2.7.4",
+				"nise": "1.4.4",
+				"supports-color": "5.5.0",
+				"type-detect": "4.0.8"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -4276,7 +4276,7 @@
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -4293,8 +4293,8 @@
 			"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
+				"buffer-from": "1.1.1",
+				"source-map": "0.6.1"
 			}
 		},
 		"spawn-command": {
@@ -4309,8 +4309,8 @@
 			"integrity": "sha1-BaW01xU6GVvJLDxCW2nzsqlSTII=",
 			"dev": true,
 			"requires": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-expression-parse": "3.0.0",
+				"spdx-license-ids": "3.0.1"
 			}
 		},
 		"spdx-exceptions": {
@@ -4322,11 +4322,11 @@
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-			"integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"dev": true,
 			"requires": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-exceptions": "2.1.0",
+				"spdx-license-ids": "3.0.1"
 			}
 		},
 		"spdx-license-ids": {
@@ -4347,10 +4347,10 @@
 			"integrity": "sha1-1DW9WXQ3Or2b2QaDWVEwhRBswF8=",
 			"dev": true,
 			"requires": {
-				"date-format": "^0.0.0",
-				"debug": "^0.7.2",
-				"mkdirp": "^0.5.1",
-				"readable-stream": "^1.1.7"
+				"date-format": "0.0.0",
+				"debug": "0.7.4",
+				"mkdirp": "0.5.1",
+				"readable-stream": "1.1.14"
 			},
 			"dependencies": {
 				"debug": {
@@ -4364,11 +4364,11 @@
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
 			}
 		},
 		"string_decoder": {
@@ -4383,7 +4383,7 @@
 			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^3.0.0"
+				"ansi-regex": "3.0.0"
 			}
 		},
 		"strip-bom": {
@@ -4404,24 +4404,24 @@
 			"integrity": "sha1-XZ0wymAvD6ClG3IPdKCRmgRlBZk=",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.3.0",
-				"commander": "^2.12.2",
-				"escodegen": "^1.8.0",
-				"esprima": "^2.7.0",
-				"glob": "^7.0.3",
-				"inquirer": "^3.0.6",
-				"istanbul-lib-instrument": "^1.9.1",
-				"lodash": "^4.17.4",
-				"log4js": "^1.1.0",
-				"mkdirp": "^0.5.1",
-				"mz": "^2.6.0",
-				"prettier": "^1.6.1",
-				"progress": "^2.0.0",
-				"rimraf": "^2.6.1",
-				"rxjs": "^5.4.3",
-				"serialize-javascript": "^1.3.0",
-				"tslib": "^1.5.0",
-				"typed-rest-client": "^0.10.0"
+				"chalk": "2.4.1",
+				"commander": "2.18.0",
+				"escodegen": "1.11.0",
+				"esprima": "2.7.3",
+				"glob": "7.1.2",
+				"inquirer": "3.3.0",
+				"istanbul-lib-instrument": "1.10.2",
+				"lodash": "4.17.11",
+				"log4js": "1.1.1",
+				"mkdirp": "0.5.1",
+				"mz": "2.7.0",
+				"prettier": "1.14.2",
+				"progress": "2.0.0",
+				"rimraf": "2.6.2",
+				"rxjs": "5.5.12",
+				"serialize-javascript": "1.5.0",
+				"tslib": "1.9.3",
+				"typed-rest-client": "0.10.0"
 			},
 			"dependencies": {
 				"commander": {
@@ -4438,7 +4438,7 @@
 			"integrity": "sha1-6erYwfK7IobVNTGY6zvL4avqtPs=",
 			"dev": true,
 			"requires": {
-				"tslib": "^1.6.0"
+				"tslib": "1.9.3"
 			}
 		},
 		"stryker-html-reporter": {
@@ -4447,13 +4447,13 @@
 			"integrity": "sha1-N+o7bKAZc1/cyrYVlbEjXlOEPiY=",
 			"dev": true,
 			"requires": {
-				"file-url": "^2.0.0",
-				"lodash": "^4.13.1",
-				"log4js": "^1.0.1",
-				"mkdirp": "^0.5.1",
-				"mz": "^2.5.0",
-				"rimraf": "^2.6.1",
-				"typed-html": "^0.6.0"
+				"file-url": "2.0.2",
+				"lodash": "4.17.11",
+				"log4js": "1.1.1",
+				"mkdirp": "0.5.1",
+				"mz": "2.7.0",
+				"rimraf": "2.6.2",
+				"typed-html": "0.6.0"
 			}
 		},
 		"stryker-mocha-framework": {
@@ -4462,7 +4462,7 @@
 			"integrity": "sha1-K1hC2pBnMhO5RuMzoTPbnZaYxb0=",
 			"dev": true,
 			"requires": {
-				"log4js": "^1.1.1"
+				"log4js": "1.1.1"
 			}
 		},
 		"stryker-mocha-runner": {
@@ -4471,8 +4471,8 @@
 			"integrity": "sha1-wcKp2WilMCJn0SeTMmDyLDetYf8=",
 			"dev": true,
 			"requires": {
-				"log4js": "^1.1.1",
-				"tslib": "^1.5.0"
+				"log4js": "1.1.1",
+				"tslib": "1.9.3"
 			}
 		},
 		"stryker-typescript": {
@@ -4481,11 +4481,11 @@
 			"integrity": "sha1-nndQ4IJiRPvfjkHvMTARpa/PkY8=",
 			"dev": true,
 			"requires": {
-				"lodash.flatmap": "^4.5.0",
-				"log4js": "^1.1.1",
-				"semver": "^5.4.1",
-				"source-map": "^0.5.6",
-				"tslib": "^1.5.0"
+				"lodash.flatmap": "4.5.0",
+				"log4js": "1.1.1",
+				"semver": "5.5.1",
+				"source-map": "0.5.7",
+				"tslib": "1.9.3"
 			},
 			"dependencies": {
 				"source-map": {
@@ -4502,7 +4502,7 @@
 			"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 			"dev": true,
 			"requires": {
-				"has-flag": "^1.0.0"
+				"has-flag": "1.0.0"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -4531,7 +4531,7 @@
 			"integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
 			"dev": true,
 			"requires": {
-				"any-promise": "^1.0.0"
+				"any-promise": "1.3.0"
 			}
 		},
 		"thenify-all": {
@@ -4540,7 +4540,7 @@
 			"integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
 			"dev": true,
 			"requires": {
-				"thenify": ">= 3.1.0 < 4"
+				"thenify": "3.3.0"
 			}
 		},
 		"through": {
@@ -4552,10 +4552,10 @@
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-			"integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "~1.0.2"
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"to-fast-properties": {
@@ -4579,17 +4579,17 @@
 		"ts-node": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-6.2.0.tgz",
-			"integrity": "sha1-ZaCuKszjGepP16yNfJ8fkMXaa68=",
+			"integrity": "sha512-ZNT+OEGfUNVMGkpIaDJJ44Zq3Yr0bkU/ugN1PHbU+/01Z7UV1fsELRiTx1KuQNvQ1A3pGh3y25iYF6jXgxV21A==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.0",
-				"buffer-from": "^1.1.0",
-				"diff": "^3.1.0",
-				"make-error": "^1.1.1",
-				"minimist": "^1.2.0",
-				"mkdirp": "^0.5.1",
-				"source-map-support": "^0.5.6",
-				"yn": "^2.0.0"
+				"arrify": "1.0.1",
+				"buffer-from": "1.1.1",
+				"diff": "3.5.0",
+				"make-error": "1.3.5",
+				"minimist": "1.2.0",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.5.9",
+				"yn": "2.0.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -4612,18 +4612,18 @@
 			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.22.0",
-				"builtin-modules": "^1.1.1",
-				"chalk": "^2.3.0",
-				"commander": "^2.12.1",
-				"diff": "^3.2.0",
-				"glob": "^7.1.1",
-				"js-yaml": "^3.7.0",
-				"minimatch": "^3.0.4",
-				"resolve": "^1.3.2",
-				"semver": "^5.3.0",
-				"tslib": "^1.8.0",
-				"tsutils": "^2.27.2"
+				"babel-code-frame": "6.26.0",
+				"builtin-modules": "1.1.1",
+				"chalk": "2.4.1",
+				"commander": "2.18.0",
+				"diff": "3.5.0",
+				"glob": "7.1.2",
+				"js-yaml": "3.12.0",
+				"minimatch": "3.0.4",
+				"resolve": "1.8.1",
+				"semver": "5.5.1",
+				"tslib": "1.9.3",
+				"tsutils": "2.29.0"
 			},
 			"dependencies": {
 				"commander": {
@@ -4640,9 +4640,9 @@
 			"integrity": "sha512-o2FhaQtxXi6FQ1v0T2n/rACNos6PhuKRmvemMpWxI+9NJn2OOlJ3+OtEmnCdoF7GPXT3Eyk+Q0q4P96flrPl3w==",
 			"dev": true,
 			"requires": {
-				"tslint-consistent-codestyle": "^1.13.3",
-				"tslint-eslint-rules": "^5.4.0",
-				"tslint-microsoft-contrib": "~5.2.0"
+				"tslint-consistent-codestyle": "1.13.3",
+				"tslint-eslint-rules": "5.4.0",
+				"tslint-microsoft-contrib": "5.2.1"
 			}
 		},
 		"tslint-consistent-codestyle": {
@@ -4651,9 +4651,9 @@
 			"integrity": "sha512-+ocXSNGHqUCUyTJsPhS7xqcC3qf6FyP4vd1jEaXaWaJ5NNN36gKZhqNt3nAWH/YgSV0tYaapjSWMbJQJmn/5MQ==",
 			"dev": true,
 			"requires": {
-				"@fimbul/bifrost": "^0.11.0",
-				"tslib": "^1.7.1",
-				"tsutils": "^2.27.0"
+				"@fimbul/bifrost": "0.11.0",
+				"tslib": "1.9.3",
+				"tsutils": "2.29.0"
 			}
 		},
 		"tslint-eslint-rules": {
@@ -4664,7 +4664,7 @@
 			"requires": {
 				"doctrine": "0.7.2",
 				"tslib": "1.9.0",
-				"tsutils": "^3.0.0"
+				"tsutils": "3.0.0"
 			},
 			"dependencies": {
 				"tslib": {
@@ -4679,7 +4679,7 @@
 					"integrity": "sha512-LjHBWR0vWAUHWdIAoTjoqi56Kz+FDKBgVEuL+gVPG/Pv7QW5IdaDDeK9Txlr6U0Cmckp5EgCIq1T25qe3J6hyw==",
 					"dev": true,
 					"requires": {
-						"tslib": "^1.8.1"
+						"tslib": "1.9.0"
 					}
 				}
 			}
@@ -4690,7 +4690,7 @@
 			"integrity": "sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==",
 			"dev": true,
 			"requires": {
-				"tsutils": "^2.27.2 <2.29.0"
+				"tsutils": "2.28.0"
 			},
 			"dependencies": {
 				"tsutils": {
@@ -4699,7 +4699,7 @@
 					"integrity": "sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==",
 					"dev": true,
 					"requires": {
-						"tslib": "^1.8.1"
+						"tslib": "1.9.3"
 					}
 				}
 			}
@@ -4710,7 +4710,7 @@
 			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
 			"dev": true,
 			"requires": {
-				"tslib": "^1.8.1"
+				"tslib": "1.9.3"
 			}
 		},
 		"tunnel": {
@@ -4725,13 +4725,13 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2"
+				"prelude-ls": "1.1.2"
 			}
 		},
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true
 		},
 		"typed-html": {
@@ -4768,17 +4768,17 @@
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
+				"spdx-correct": "3.0.0",
+				"spdx-expression-parse": "3.0.0"
 			}
 		},
 		"which": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"dev": true,
 			"requires": {
-				"isexe": "^2.0.0"
+				"isexe": "2.0.0"
 			}
 		},
 		"which-module": {
@@ -4799,8 +4799,8 @@
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4815,7 +4815,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"string-width": {
@@ -4824,9 +4824,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"strip-ansi": {
@@ -4835,7 +4835,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				}
 			}
@@ -4860,22 +4860,22 @@
 		},
 		"yargs": {
 			"version": "11.1.0",
-			"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 			"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 			"dev": true,
 			"requires": {
-				"cliui": "^4.0.0",
-				"decamelize": "^1.1.1",
-				"find-up": "^2.1.0",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^2.0.0",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
-				"set-blocking": "^2.0.0",
-				"string-width": "^2.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^3.2.1",
-				"yargs-parser": "^9.0.2"
+				"cliui": "4.1.0",
+				"decamelize": "1.2.0",
+				"find-up": "2.1.0",
+				"get-caller-file": "1.0.3",
+				"os-locale": "2.1.0",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "2.1.1",
+				"which-module": "2.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "9.0.2"
 			}
 		},
 		"yargs-parser": {
@@ -4884,7 +4884,7 @@
 			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^4.1.0"
+				"camelcase": "4.1.0"
 			}
 		},
 		"yn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
 			"integrity": "sha1-g8rMIUZBmLEuPMHCIErmxtev0Vg=",
 			"dev": true,
 			"requires": {
-				"@fimbul/ymir": "0.11.0",
-				"get-caller-file": "1.0.3",
-				"tslib": "1.9.3",
-				"tsutils": "2.29.0"
+				"@fimbul/ymir": "^0.11.0",
+				"get-caller-file": "^1.0.2",
+				"tslib": "^1.8.1",
+				"tsutils": "^2.24.0"
 			}
 		},
 		"@fimbul/ymir": {
@@ -22,9 +22,9 @@
 			"integrity": "sha1-iSoBmX8fgMfk5DfPXKUclZlME28=",
 			"dev": true,
 			"requires": {
-				"inversify": "4.13.0",
-				"reflect-metadata": "0.1.12",
-				"tslib": "1.9.3"
+				"inversify": "^4.10.0",
+				"reflect-metadata": "^0.1.12",
+				"tslib": "^1.8.1"
 			}
 		},
 		"@sinonjs/formatio": {
@@ -48,7 +48,7 @@
 			"integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
 			"dev": true,
 			"requires": {
-				"axios": "0.18.0"
+				"axios": "*"
 			}
 		},
 		"@types/chai": {
@@ -105,7 +105,7 @@
 			"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 			"dev": true,
 			"requires": {
-				"color-convert": "1.9.3"
+				"color-convert": "^1.9.0"
 			}
 		},
 		"any-promise": {
@@ -126,7 +126,7 @@
 			"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"arrify": {
@@ -146,8 +146,8 @@
 			"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
 			"integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
 			"requires": {
-				"follow-redirects": "1.5.8",
-				"is-buffer": "1.1.6"
+				"follow-redirects": "^1.3.0",
+				"is-buffer": "^1.1.5"
 			}
 		},
 		"axios-mock-adapter": {
@@ -156,7 +156,7 @@
 			"integrity": "sha1-+8BoJdgwLJXDM00hAju6mWJV1F0=",
 			"dev": true,
 			"requires": {
-				"deep-equal": "1.0.1"
+				"deep-equal": "^1.0.1"
 			}
 		},
 		"babel-code-frame": {
@@ -165,9 +165,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -188,11 +188,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -201,7 +201,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"supports-color": {
@@ -218,14 +218,14 @@
 			"integrity": "sha1-GERAjTuPDTWkBOp6wYDwh6YBvZA=",
 			"dev": true,
 			"requires": {
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"detect-indent": "4.0.0",
-				"jsesc": "1.3.0",
-				"lodash": "4.17.11",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"detect-indent": "^4.0.0",
+				"jsesc": "^1.3.0",
+				"lodash": "^4.17.4",
+				"source-map": "^0.5.7",
+				"trim-right": "^1.0.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -242,7 +242,7 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-runtime": {
@@ -251,8 +251,8 @@
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"dev": true,
 			"requires": {
-				"core-js": "2.5.7",
-				"regenerator-runtime": "0.11.1"
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
 			}
 		},
 		"babel-template": {
@@ -261,11 +261,11 @@
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"lodash": "4.17.11"
+				"babel-runtime": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-traverse": {
@@ -274,15 +274,15 @@
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"debug": "2.6.9",
-				"globals": "9.18.0",
-				"invariant": "2.2.4",
-				"lodash": "4.17.11"
+				"babel-code-frame": "^6.26.0",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"debug": "^2.6.8",
+				"globals": "^9.18.0",
+				"invariant": "^2.2.2",
+				"lodash": "^4.17.4"
 			},
 			"dependencies": {
 				"debug": {
@@ -302,10 +302,10 @@
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"esutils": "2.0.2",
-				"lodash": "4.17.11",
-				"to-fast-properties": "1.0.3"
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"babylon": {
@@ -326,7 +326,7 @@
 			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
 			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -360,12 +360,12 @@
 			"integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
 			"dev": true,
 			"requires": {
-				"assertion-error": "1.1.0",
-				"check-error": "1.0.2",
-				"deep-eql": "3.0.1",
-				"get-func-name": "2.0.0",
-				"pathval": "1.1.0",
-				"type-detect": "4.0.8"
+				"assertion-error": "^1.0.1",
+				"check-error": "^1.0.1",
+				"deep-eql": "^3.0.0",
+				"get-func-name": "^2.0.0",
+				"pathval": "^1.0.0",
+				"type-detect": "^4.0.0"
 			}
 		},
 		"chalk": {
@@ -374,9 +374,9 @@
 			"integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.5.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -385,7 +385,7 @@
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -413,7 +413,7 @@
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "2.0.0"
+				"restore-cursor": "^2.0.0"
 			}
 		},
 		"cli-width": {
@@ -428,9 +428,9 @@
 			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 			"dev": true,
 			"requires": {
-				"string-width": "2.1.1",
-				"strip-ansi": "4.0.0",
-				"wrap-ansi": "2.1.0"
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
 			}
 		},
 		"code-point-at": {
@@ -472,15 +472,15 @@
 			"integrity": "sha512-/+ugz+gwFSEfTGUxn0KHkY+19XPRTXR8+7oUK/HxgiN1n7FjeJmkrbSiXAJfyQ0zORgJYPaenmymwon51YXH9Q==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
+				"chalk": "^2.4.1",
 				"commander": "2.6.0",
-				"date-fns": "1.29.0",
-				"lodash": "4.17.11",
-				"read-pkg": "3.0.0",
+				"date-fns": "^1.23.0",
+				"lodash": "^4.5.1",
+				"read-pkg": "^3.0.0",
 				"rx": "2.3.24",
-				"spawn-command": "0.0.2-1",
-				"supports-color": "3.2.3",
-				"tree-kill": "1.2.0"
+				"spawn-command": "^0.0.2-1",
+				"supports-color": "^3.2.3",
+				"tree-kill": "^1.1.0"
 			}
 		},
 		"core-js": {
@@ -501,11 +501,11 @@
 			"integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
 			"dev": true,
 			"requires": {
-				"nice-try": "1.0.5",
-				"path-key": "2.0.1",
-				"semver": "5.5.1",
-				"shebang-command": "1.2.0",
-				"which": "1.3.1"
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
 			}
 		},
 		"date-fns": {
@@ -540,7 +540,7 @@
 			"integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
 			"dev": true,
 			"requires": {
-				"type-detect": "4.0.8"
+				"type-detect": "^4.0.0"
 			}
 		},
 		"deep-equal": {
@@ -561,7 +561,7 @@
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"dev": true,
 			"requires": {
-				"repeating": "2.0.1"
+				"repeating": "^2.0.0"
 			}
 		},
 		"diff": {
@@ -576,7 +576,7 @@
 			"integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
 			"dev": true,
 			"requires": {
-				"esutils": "1.1.6",
+				"esutils": "^1.1.6",
 				"isarray": "0.0.1"
 			},
 			"dependencies": {
@@ -594,7 +594,7 @@
 			"integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"escape-string-regexp": {
@@ -609,11 +609,11 @@
 			"integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
 			"dev": true,
 			"requires": {
-				"esprima": "3.1.3",
-				"estraverse": "4.2.0",
-				"esutils": "2.0.2",
-				"optionator": "0.8.2",
-				"source-map": "0.6.1"
+				"esprima": "^3.1.3",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"esprima": {
@@ -648,13 +648,13 @@
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "5.1.0",
-				"get-stream": "3.0.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -663,9 +663,9 @@
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"dev": true,
 					"requires": {
-						"lru-cache": "4.1.3",
-						"shebang-command": "1.2.0",
-						"which": "1.3.1"
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				}
 			}
@@ -676,9 +676,9 @@
 			"integrity": "sha1-BFURz9jRM/OEZnPRBHwVTiFK09U=",
 			"dev": true,
 			"requires": {
-				"chardet": "0.4.2",
-				"iconv-lite": "0.4.24",
-				"tmp": "0.0.33"
+				"chardet": "^0.4.0",
+				"iconv-lite": "^0.4.17",
+				"tmp": "^0.0.33"
 			}
 		},
 		"faker": {
@@ -699,7 +699,7 @@
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "1.0.5"
+				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"file-url": {
@@ -714,7 +714,7 @@
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"dev": true,
 			"requires": {
-				"locate-path": "2.0.0"
+				"locate-path": "^2.0.0"
 			}
 		},
 		"follow-redirects": {
@@ -722,7 +722,7 @@
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.8.tgz",
 			"integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
 			"requires": {
-				"debug": "3.1.0"
+				"debug": "=3.1.0"
 			}
 		},
 		"fs.realpath": {
@@ -755,12 +755,12 @@
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"globals": {
@@ -787,7 +787,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -822,7 +822,7 @@
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": "2.1.2"
+				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
 		"inflight": {
@@ -831,8 +831,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -847,20 +847,20 @@
 			"integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "3.1.0",
-				"chalk": "2.4.1",
-				"cli-cursor": "2.1.0",
-				"cli-width": "2.2.0",
-				"external-editor": "2.2.0",
-				"figures": "2.0.0",
-				"lodash": "4.17.11",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.0",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^2.0.4",
+				"figures": "^2.0.0",
+				"lodash": "^4.3.0",
 				"mute-stream": "0.0.7",
-				"run-async": "2.3.0",
-				"rx-lite": "4.0.8",
-				"rx-lite-aggregates": "4.0.8",
-				"string-width": "2.1.1",
-				"strip-ansi": "4.0.0",
-				"through": "2.3.8"
+				"run-async": "^2.2.0",
+				"rx-lite": "^4.0.8",
+				"rx-lite-aggregates": "^4.0.8",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^4.0.0",
+				"through": "^2.3.6"
 			}
 		},
 		"invariant": {
@@ -869,7 +869,7 @@
 			"integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
 			"dev": true,
 			"requires": {
-				"loose-envify": "1.4.0"
+				"loose-envify": "^1.0.0"
 			}
 		},
 		"inversify": {
@@ -901,7 +901,7 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "1.1.1"
+				"builtin-modules": "^1.0.0"
 			}
 		},
 		"is-finite": {
@@ -910,7 +910,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -955,13 +955,13 @@
 			"integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
 			"dev": true,
 			"requires": {
-				"babel-generator": "6.26.1",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"istanbul-lib-coverage": "1.2.1",
-				"semver": "5.5.1"
+				"babel-generator": "^6.18.0",
+				"babel-template": "^6.16.0",
+				"babel-traverse": "^6.18.0",
+				"babel-types": "^6.18.0",
+				"babylon": "^6.18.0",
+				"istanbul-lib-coverage": "^1.2.1",
+				"semver": "^5.3.0"
 			}
 		},
 		"js-tokens": {
@@ -976,8 +976,8 @@
 			"integrity": "sha1-6u1lbsg0TxD1J8a/obbiJE3hZ9E=",
 			"dev": true,
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.1"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			},
 			"dependencies": {
 				"esprima": {
@@ -1012,7 +1012,7 @@
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"dev": true,
 			"requires": {
-				"invert-kv": "1.0.0"
+				"invert-kv": "^1.0.0"
 			}
 		},
 		"levn": {
@@ -1021,8 +1021,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"load-json-file": {
@@ -1031,10 +1031,10 @@
 			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "4.0.0",
-				"pify": "3.0.0",
-				"strip-bom": "3.0.0"
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"locate-path": {
@@ -1043,8 +1043,8 @@
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
@@ -1071,9 +1071,9 @@
 			"integrity": "sha1-wh0px2BAieTyVYM+f5SzRh3h/0M=",
 			"dev": true,
 			"requires": {
-				"debug": "2.6.9",
-				"semver": "5.5.1",
-				"streamroller": "0.4.1"
+				"debug": "^2.2.0",
+				"semver": "^5.3.0",
+				"streamroller": "^0.4.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -1099,7 +1099,7 @@
 			"integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
 			"dev": true,
 			"requires": {
-				"js-tokens": "3.0.2"
+				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
 		"lru-cache": {
@@ -1108,8 +1108,8 @@
 			"integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
 			"dev": true,
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"make-error": {
@@ -1124,7 +1124,7 @@
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "1.2.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"mimic-fn": {
@@ -1139,7 +1139,7 @@
 			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -1188,7 +1188,7 @@
 					"integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -1199,10 +1199,10 @@
 			"integrity": "sha1-94sprU+H/OjCX2V4g+Pso5+wJsk=",
 			"dev": true,
 			"requires": {
-				"@types/mocha": "5.2.5",
-				"chalk": "2.4.1",
-				"cross-spawn": "6.0.5",
-				"yargs": "11.1.0"
+				"@types/mocha": "^5.2.0",
+				"chalk": "^2.4.1",
+				"cross-spawn": "^6.0.5",
+				"yargs": "^11.0.0"
 			}
 		},
 		"ms": {
@@ -1222,9 +1222,9 @@
 			"integrity": "sha1-lQCAV6Vsr63CvGPd5/n/aVWUjjI=",
 			"dev": true,
 			"requires": {
-				"any-promise": "1.3.0",
-				"object-assign": "4.1.1",
-				"thenify-all": "1.6.0"
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
 			}
 		},
 		"nice-try": {
@@ -1239,11 +1239,11 @@
 			"integrity": "sha512-pxE0c9PzgrUTyhfv5p+5eMIdfU2bLEsq8VQEuE0kxM4zP7SujSar7rk9wpI2F7RyyCEvLyj5O7Is3RER5F36Fg==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "2.0.0",
-				"just-extend": "3.0.0",
-				"lolex": "2.7.4",
-				"path-to-regexp": "1.7.0",
-				"text-encoding": "0.6.4"
+				"@sinonjs/formatio": "^2.0.0",
+				"just-extend": "^3.0.0",
+				"lolex": "^2.3.2",
+				"path-to-regexp": "^1.7.0",
+				"text-encoding": "^0.6.4"
 			}
 		},
 		"normalize-package-data": {
@@ -1252,10 +1252,10 @@
 			"integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "2.7.1",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.5.1",
-				"validate-npm-package-license": "3.0.4"
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"npm-run-path": {
@@ -1264,7 +1264,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "2.0.1"
+				"path-key": "^2.0.0"
 			}
 		},
 		"number-is-nan": {
@@ -1279,33 +1279,33 @@
 			"integrity": "sha1-QQbono++c2I6H8i27Lerqica4eQ=",
 			"dev": true,
 			"requires": {
-				"archy": "1.0.0",
-				"arrify": "1.0.1",
-				"caching-transform": "1.0.1",
-				"convert-source-map": "1.5.1",
-				"debug-log": "1.0.1",
-				"default-require-extensions": "1.0.0",
-				"find-cache-dir": "0.1.1",
-				"find-up": "2.1.0",
-				"foreground-child": "1.5.6",
-				"glob": "7.1.2",
-				"istanbul-lib-coverage": "1.2.0",
-				"istanbul-lib-hook": "1.1.0",
-				"istanbul-lib-instrument": "1.10.1",
-				"istanbul-lib-report": "1.1.3",
-				"istanbul-lib-source-maps": "1.2.3",
-				"istanbul-reports": "1.4.0",
-				"md5-hex": "1.3.0",
-				"merge-source-map": "1.1.0",
-				"micromatch": "3.1.10",
-				"mkdirp": "0.5.1",
-				"resolve-from": "2.0.0",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"spawn-wrap": "1.4.2",
-				"test-exclude": "4.2.1",
+				"archy": "^1.0.0",
+				"arrify": "^1.0.1",
+				"caching-transform": "^1.0.0",
+				"convert-source-map": "^1.5.1",
+				"debug-log": "^1.0.1",
+				"default-require-extensions": "^1.0.0",
+				"find-cache-dir": "^0.1.1",
+				"find-up": "^2.1.0",
+				"foreground-child": "^1.5.3",
+				"glob": "^7.0.6",
+				"istanbul-lib-coverage": "^1.1.2",
+				"istanbul-lib-hook": "^1.1.0",
+				"istanbul-lib-instrument": "^1.10.0",
+				"istanbul-lib-report": "^1.1.3",
+				"istanbul-lib-source-maps": "^1.2.3",
+				"istanbul-reports": "^1.4.0",
+				"md5-hex": "^1.2.0",
+				"merge-source-map": "^1.1.0",
+				"micromatch": "^3.1.10",
+				"mkdirp": "^0.5.0",
+				"resolve-from": "^2.0.0",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.1",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^4.2.0",
 				"yargs": "11.1.0",
-				"yargs-parser": "8.1.0"
+				"yargs-parser": "^8.0.0"
 			},
 			"dependencies": {
 				"align-text": {
@@ -1313,9 +1313,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2",
-						"longest": "1.0.1",
-						"repeat-string": "1.6.1"
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
 					}
 				},
 				"amdefine": {
@@ -1338,7 +1338,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"default-require-extensions": "1.0.0"
+						"default-require-extensions": "^1.0.0"
 					}
 				},
 				"archy": {
@@ -1391,9 +1391,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"esutils": "2.0.2",
-						"js-tokens": "3.0.2"
+						"chalk": "^1.1.3",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.2"
 					}
 				},
 				"babel-generator": {
@@ -1401,14 +1401,14 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"detect-indent": "4.0.0",
-						"jsesc": "1.3.0",
-						"lodash": "4.17.10",
-						"source-map": "0.5.7",
-						"trim-right": "1.0.1"
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"detect-indent": "^4.0.0",
+						"jsesc": "^1.3.0",
+						"lodash": "^4.17.4",
+						"source-map": "^0.5.7",
+						"trim-right": "^1.0.1"
 					}
 				},
 				"babel-messages": {
@@ -1416,7 +1416,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-runtime": "6.26.0"
+						"babel-runtime": "^6.22.0"
 					}
 				},
 				"babel-runtime": {
@@ -1424,8 +1424,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"core-js": "2.5.6",
-						"regenerator-runtime": "0.11.1"
+						"core-js": "^2.4.0",
+						"regenerator-runtime": "^0.11.0"
 					}
 				},
 				"babel-template": {
@@ -1433,11 +1433,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-runtime": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"lodash": "4.17.10"
+						"babel-runtime": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"lodash": "^4.17.4"
 					}
 				},
 				"babel-traverse": {
@@ -1445,15 +1445,15 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"debug": "2.6.9",
-						"globals": "9.18.0",
-						"invariant": "2.2.4",
-						"lodash": "4.17.10"
+						"babel-code-frame": "^6.26.0",
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"debug": "^2.6.8",
+						"globals": "^9.18.0",
+						"invariant": "^2.2.2",
+						"lodash": "^4.17.4"
 					}
 				},
 				"babel-types": {
@@ -1461,10 +1461,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-runtime": "6.26.0",
-						"esutils": "2.0.2",
-						"lodash": "4.17.10",
-						"to-fast-properties": "1.0.3"
+						"babel-runtime": "^6.26.0",
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.4",
+						"to-fast-properties": "^1.0.3"
 					}
 				},
 				"babylon": {
@@ -1482,13 +1482,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cache-base": "1.0.1",
-						"class-utils": "0.3.6",
-						"component-emitter": "1.2.1",
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"mixin-deep": "1.3.1",
-						"pascalcase": "0.1.1"
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1496,7 +1496,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -1504,7 +1504,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
@@ -1512,7 +1512,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
@@ -1520,9 +1520,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -1542,7 +1542,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -1551,16 +1551,16 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -1568,7 +1568,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1583,15 +1583,15 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"collection-visit": "1.0.0",
-						"component-emitter": "1.2.1",
-						"get-value": "2.0.6",
-						"has-value": "1.0.0",
-						"isobject": "3.0.1",
-						"set-value": "2.0.0",
-						"to-object-path": "0.3.0",
-						"union-value": "1.0.0",
-						"unset-value": "1.0.0"
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1606,9 +1606,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"md5-hex": "1.3.0",
-						"mkdirp": "0.5.1",
-						"write-file-atomic": "1.3.4"
+						"md5-hex": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"write-file-atomic": "^1.1.4"
 					}
 				},
 				"camelcase": {
@@ -1623,8 +1623,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4",
-						"lazy-cache": "1.0.4"
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
 					}
 				},
 				"chalk": {
@@ -1632,11 +1632,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"class-utils": {
@@ -1644,10 +1644,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arr-union": "3.1.0",
-						"define-property": "0.2.5",
-						"isobject": "3.0.1",
-						"static-extend": "0.1.2"
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1655,7 +1655,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"isobject": {
@@ -1671,8 +1671,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
 						"wordwrap": "0.0.2"
 					},
 					"dependencies": {
@@ -1694,8 +1694,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"map-visit": "1.0.0",
-						"object-visit": "1.0.1"
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
 					}
 				},
 				"commondir": {
@@ -1733,8 +1733,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"lru-cache": "4.1.3",
-						"which": "1.3.0"
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -1765,7 +1765,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"strip-bom": "2.0.0"
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"define-property": {
@@ -1773,8 +1773,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2",
-						"isobject": "3.0.1"
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"is-accessor-descriptor": {
@@ -1782,7 +1782,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
@@ -1790,7 +1790,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
@@ -1798,9 +1798,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -1820,7 +1820,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"repeating": "2.0.1"
+						"repeating": "^2.0.0"
 					}
 				},
 				"error-ex": {
@@ -1828,7 +1828,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-arrayish": "0.2.1"
+						"is-arrayish": "^0.2.1"
 					}
 				},
 				"escape-string-regexp": {
@@ -1846,13 +1846,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					},
 					"dependencies": {
 						"cross-spawn": {
@@ -1860,9 +1860,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"lru-cache": "4.1.3",
-								"shebang-command": "1.2.0",
-								"which": "1.3.0"
+								"lru-cache": "^4.0.1",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
 							}
 						}
 					}
@@ -1872,13 +1872,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1886,7 +1886,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -1894,7 +1894,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1904,8 +1904,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"assign-symbols": "1.0.0",
-						"is-extendable": "1.0.1"
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
@@ -1913,7 +1913,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -1923,14 +1923,14 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1938,7 +1938,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -1946,7 +1946,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -1954,7 +1954,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
@@ -1962,7 +1962,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
@@ -1970,9 +1970,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"kind-of": {
@@ -1987,10 +1987,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -1998,7 +1998,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2008,9 +2008,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"commondir": "1.0.1",
-						"mkdirp": "0.5.1",
-						"pkg-dir": "1.0.0"
+						"commondir": "^1.0.1",
+						"mkdirp": "^0.5.1",
+						"pkg-dir": "^1.0.0"
 					}
 				},
 				"find-up": {
@@ -2018,7 +2018,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"for-in": {
@@ -2031,8 +2031,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cross-spawn": "4.0.2",
-						"signal-exit": "3.0.2"
+						"cross-spawn": "^4",
+						"signal-exit": "^3.0.0"
 					}
 				},
 				"fragment-cache": {
@@ -2040,7 +2040,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"map-cache": "0.2.2"
+						"map-cache": "^0.2.2"
 					}
 				},
 				"fs.realpath": {
@@ -2068,12 +2068,12 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"globals": {
@@ -2091,10 +2091,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"async": "1.5.2",
-						"optimist": "0.6.1",
-						"source-map": "0.4.4",
-						"uglify-js": "2.8.29"
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
 					},
 					"dependencies": {
 						"source-map": {
@@ -2102,7 +2102,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"amdefine": "1.0.1"
+								"amdefine": ">=0.0.4"
 							}
 						}
 					}
@@ -2112,7 +2112,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -2125,9 +2125,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "1.0.0",
-						"isobject": "3.0.1"
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -2142,8 +2142,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-number": "3.0.0",
-						"kind-of": "4.0.0"
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
@@ -2151,7 +2151,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -2159,7 +2159,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -2169,7 +2169,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -2189,8 +2189,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -2203,7 +2203,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"loose-envify": "1.3.1"
+						"loose-envify": "^1.0.0"
 					}
 				},
 				"invert-kv": {
@@ -2216,7 +2216,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-arrayish": {
@@ -2234,7 +2234,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"builtin-modules": "1.1.1"
+						"builtin-modules": "^1.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -2242,7 +2242,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -2250,9 +2250,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2272,7 +2272,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -2285,7 +2285,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-odd": {
@@ -2293,7 +2293,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-number": "4.0.0"
+						"is-number": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
@@ -2308,7 +2308,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -2358,7 +2358,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"append-transform": "0.4.0"
+						"append-transform": "^0.4.0"
 					}
 				},
 				"istanbul-lib-instrument": {
@@ -2366,13 +2366,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-generator": "6.26.1",
-						"babel-template": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"semver": "5.5.0"
+						"babel-generator": "^6.18.0",
+						"babel-template": "^6.16.0",
+						"babel-traverse": "^6.18.0",
+						"babel-types": "^6.18.0",
+						"babylon": "^6.18.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"semver": "^5.3.0"
 					}
 				},
 				"istanbul-lib-report": {
@@ -2380,10 +2380,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"path-parse": "1.0.5",
-						"supports-color": "3.2.3"
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"path-parse": "^1.0.5",
+						"supports-color": "^3.1.2"
 					},
 					"dependencies": {
 						"supports-color": {
@@ -2391,7 +2391,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"has-flag": "1.0.0"
+								"has-flag": "^1.0.0"
 							}
 						}
 					}
@@ -2401,11 +2401,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"debug": "3.1.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"source-map": "0.5.7"
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.6.1",
+						"source-map": "^0.5.3"
 					},
 					"dependencies": {
 						"debug": {
@@ -2423,7 +2423,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"handlebars": "4.0.11"
+						"handlebars": "^4.0.3"
 					}
 				},
 				"js-tokens": {
@@ -2441,7 +2441,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				},
 				"lazy-cache": {
@@ -2455,7 +2455,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -2463,11 +2463,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"locate-path": {
@@ -2475,8 +2475,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					},
 					"dependencies": {
 						"path-exists": {
@@ -2501,7 +2501,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"js-tokens": "3.0.2"
+						"js-tokens": "^3.0.0"
 					}
 				},
 				"lru-cache": {
@@ -2509,8 +2509,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"map-cache": {
@@ -2523,7 +2523,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"object-visit": "1.0.1"
+						"object-visit": "^1.0.0"
 					}
 				},
 				"md5-hex": {
@@ -2531,7 +2531,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"md5-o-matic": "0.1.1"
+						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"md5-o-matic": {
@@ -2544,7 +2544,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"merge-source-map": {
@@ -2552,7 +2552,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"source-map": "0.6.1"
+						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
@@ -2567,19 +2567,19 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2599,7 +2599,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -2612,8 +2612,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"for-in": "1.0.2",
-						"is-extendable": "1.0.1"
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
@@ -2621,7 +2621,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -2644,18 +2644,18 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"fragment-cache": "0.2.1",
-						"is-odd": "2.0.0",
-						"is-windows": "1.0.2",
-						"kind-of": "6.0.2",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -2680,10 +2680,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "2.6.0",
-						"is-builtin-module": "1.0.0",
-						"semver": "5.5.0",
-						"validate-npm-package-license": "3.0.3"
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"npm-run-path": {
@@ -2691,7 +2691,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"path-key": "2.0.1"
+						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -2709,9 +2709,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"copy-descriptor": "0.1.1",
-						"define-property": "0.2.5",
-						"kind-of": "3.2.2"
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
 					},
 					"dependencies": {
 						"define-property": {
@@ -2719,7 +2719,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -2729,7 +2729,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -2744,7 +2744,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -2759,7 +2759,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"optimist": {
@@ -2767,8 +2767,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"minimist": "0.0.8",
-						"wordwrap": "0.0.3"
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
 					}
 				},
 				"os-homedir": {
@@ -2781,9 +2781,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
 				},
 				"p-finally": {
@@ -2796,7 +2796,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
@@ -2804,7 +2804,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-limit": "1.2.0"
+						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
@@ -2817,7 +2817,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.1"
+						"error-ex": "^1.2.0"
 					}
 				},
 				"pascalcase": {
@@ -2830,7 +2830,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-is-absolute": {
@@ -2853,9 +2853,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"pify": {
@@ -2873,7 +2873,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pinkie": "2.0.4"
+						"pinkie": "^2.0.0"
 					}
 				},
 				"pkg-dir": {
@@ -2881,7 +2881,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"find-up": "1.1.2"
+						"find-up": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
@@ -2889,8 +2889,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -2910,9 +2910,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -2920,8 +2920,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
@@ -2929,8 +2929,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -2945,8 +2945,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"extend-shallow": "3.0.2",
-						"safe-regex": "1.1.0"
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"repeat-element": {
@@ -2964,7 +2964,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-finite": "1.0.2"
+						"is-finite": "^1.0.0"
 					}
 				},
 				"require-directory": {
@@ -2998,7 +2998,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4"
+						"align-text": "^0.1.1"
 					}
 				},
 				"rimraf": {
@@ -3006,7 +3006,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-regex": {
@@ -3014,7 +3014,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ret": "0.1.15"
+						"ret": "~0.1.10"
 					}
 				},
 				"semver": {
@@ -3032,10 +3032,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"split-string": "3.1.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -3043,7 +3043,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -3053,7 +3053,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"shebang-regex": "1.0.0"
+						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -3076,14 +3076,14 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"base": "0.11.2",
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"map-cache": "0.2.2",
-						"source-map": "0.5.7",
-						"source-map-resolve": "0.5.1",
-						"use": "3.1.0"
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
 					},
 					"dependencies": {
 						"define-property": {
@@ -3091,7 +3091,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -3099,7 +3099,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -3109,9 +3109,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"snapdragon-util": "3.0.1"
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -3119,7 +3119,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -3127,7 +3127,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
@@ -3135,7 +3135,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
@@ -3143,9 +3143,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -3165,7 +3165,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.2.0"
 					}
 				},
 				"source-map": {
@@ -3178,11 +3178,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"atob": "2.1.1",
-						"decode-uri-component": "0.2.0",
-						"resolve-url": "0.2.1",
-						"source-map-url": "0.4.0",
-						"urix": "0.1.0"
+						"atob": "^2.0.0",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
 					}
 				},
 				"source-map-url": {
@@ -3195,12 +3195,12 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"foreground-child": "1.5.6",
-						"mkdirp": "0.5.1",
-						"os-homedir": "1.0.2",
-						"rimraf": "2.6.2",
-						"signal-exit": "3.0.2",
-						"which": "1.3.0"
+						"foreground-child": "^1.5.6",
+						"mkdirp": "^0.5.0",
+						"os-homedir": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.2",
+						"which": "^1.3.0"
 					}
 				},
 				"spdx-correct": {
@@ -3208,8 +3208,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-expression-parse": "3.0.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -3222,8 +3222,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-exceptions": "2.1.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -3236,7 +3236,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"extend-shallow": "3.0.2"
+						"extend-shallow": "^3.0.0"
 					}
 				},
 				"static-extend": {
@@ -3244,8 +3244,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"define-property": "0.2.5",
-						"object-copy": "0.1.0"
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
 					},
 					"dependencies": {
 						"define-property": {
@@ -3253,7 +3253,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -3263,8 +3263,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -3277,7 +3277,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						}
 					}
@@ -3287,7 +3287,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-bom": {
@@ -3295,7 +3295,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"strip-eof": {
@@ -3313,11 +3313,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arrify": "1.0.1",
-						"micromatch": "3.1.10",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"require-main-filename": "1.0.1"
+						"arrify": "^1.0.1",
+						"micromatch": "^3.1.8",
+						"object-assign": "^4.1.0",
+						"read-pkg-up": "^1.0.1",
+						"require-main-filename": "^1.0.1"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -3335,16 +3335,16 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arr-flatten": "1.1.0",
-								"array-unique": "0.3.2",
-								"extend-shallow": "2.0.1",
-								"fill-range": "4.0.0",
-								"isobject": "3.0.1",
-								"repeat-element": "1.1.2",
-								"snapdragon": "0.8.2",
-								"snapdragon-node": "2.1.1",
-								"split-string": "3.1.0",
-								"to-regex": "3.0.2"
+								"arr-flatten": "^1.1.0",
+								"array-unique": "^0.3.2",
+								"extend-shallow": "^2.0.1",
+								"fill-range": "^4.0.0",
+								"isobject": "^3.0.1",
+								"repeat-element": "^1.1.2",
+								"snapdragon": "^0.8.1",
+								"snapdragon-node": "^2.0.1",
+								"split-string": "^3.0.2",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"extend-shallow": {
@@ -3352,7 +3352,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -3362,13 +3362,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"debug": "2.6.9",
-								"define-property": "0.2.5",
-								"extend-shallow": "2.0.1",
-								"posix-character-classes": "0.1.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"debug": "^2.3.3",
+								"define-property": "^0.2.5",
+								"extend-shallow": "^2.0.1",
+								"posix-character-classes": "^0.1.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
@@ -3376,7 +3376,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								},
 								"extend-shallow": {
@@ -3384,7 +3384,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								},
 								"is-accessor-descriptor": {
@@ -3392,7 +3392,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
@@ -3400,7 +3400,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -3410,7 +3410,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
@@ -3418,7 +3418,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -3428,9 +3428,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-accessor-descriptor": "0.1.6",
-										"is-data-descriptor": "0.1.4",
-										"kind-of": "5.1.0"
+										"is-accessor-descriptor": "^0.1.6",
+										"is-data-descriptor": "^0.1.4",
+										"kind-of": "^5.0.0"
 									}
 								},
 								"kind-of": {
@@ -3445,14 +3445,14 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"array-unique": "0.3.2",
-								"define-property": "1.0.0",
-								"expand-brackets": "2.1.4",
-								"extend-shallow": "2.0.1",
-								"fragment-cache": "0.2.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"array-unique": "^0.3.2",
+								"define-property": "^1.0.0",
+								"expand-brackets": "^2.1.4",
+								"extend-shallow": "^2.0.1",
+								"fragment-cache": "^0.2.1",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
@@ -3460,7 +3460,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "1.0.2"
+										"is-descriptor": "^1.0.0"
 									}
 								},
 								"extend-shallow": {
@@ -3468,7 +3468,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -3478,10 +3478,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-number": "3.0.0",
-								"repeat-string": "1.6.1",
-								"to-regex-range": "2.1.1"
+								"extend-shallow": "^2.0.1",
+								"is-number": "^3.0.0",
+								"repeat-string": "^1.6.1",
+								"to-regex-range": "^2.1.0"
 							},
 							"dependencies": {
 								"extend-shallow": {
@@ -3489,7 +3489,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -3499,7 +3499,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
@@ -3507,7 +3507,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
@@ -3515,9 +3515,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"is-number": {
@@ -3525,7 +3525,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -3533,7 +3533,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -3553,19 +3553,19 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arr-diff": "4.0.0",
-								"array-unique": "0.3.2",
-								"braces": "2.3.2",
-								"define-property": "2.0.2",
-								"extend-shallow": "3.0.2",
-								"extglob": "2.0.4",
-								"fragment-cache": "0.2.1",
-								"kind-of": "6.0.2",
-								"nanomatch": "1.2.9",
-								"object.pick": "1.3.0",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"arr-diff": "^4.0.0",
+								"array-unique": "^0.3.2",
+								"braces": "^2.3.1",
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"extglob": "^2.0.4",
+								"fragment-cache": "^0.2.1",
+								"kind-of": "^6.0.2",
+								"nanomatch": "^1.2.9",
+								"object.pick": "^1.3.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.2"
 							}
 						}
 					}
@@ -3580,7 +3580,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"to-regex": {
@@ -3588,10 +3588,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"regex-not": "1.0.2",
-						"safe-regex": "1.1.0"
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"to-regex-range": {
@@ -3599,8 +3599,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1"
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
 					},
 					"dependencies": {
 						"is-number": {
@@ -3608,7 +3608,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						}
 					}
@@ -3624,9 +3624,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"source-map": "0.5.7",
-						"uglify-to-browserify": "1.0.2",
-						"yargs": "3.10.0"
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
 					},
 					"dependencies": {
 						"yargs": {
@@ -3635,9 +3635,9 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"camelcase": "1.2.1",
-								"cliui": "2.1.0",
-								"decamelize": "1.2.0",
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
 								"window-size": "0.1.0"
 							}
 						}
@@ -3654,10 +3654,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arr-union": "3.1.0",
-						"get-value": "2.0.6",
-						"is-extendable": "0.1.1",
-						"set-value": "0.4.3"
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -3665,7 +3665,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"set-value": {
@@ -3673,10 +3673,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-extendable": "0.1.1",
-								"is-plain-object": "2.0.4",
-								"to-object-path": "0.3.0"
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
 							}
 						}
 					}
@@ -3686,8 +3686,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"has-value": "0.3.1",
-						"isobject": "3.0.1"
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"has-value": {
@@ -3695,9 +3695,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"get-value": "2.0.6",
-								"has-values": "0.1.4",
-								"isobject": "2.1.0"
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -3732,7 +3732,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -3747,8 +3747,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-correct": "3.0.0",
-						"spdx-expression-parse": "3.0.0"
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
 					}
 				},
 				"which": {
@@ -3756,7 +3756,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"isexe": "2.0.0"
+						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
@@ -3780,8 +3780,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					},
 					"dependencies": {
 						"is-fullwidth-code-point": {
@@ -3789,7 +3789,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
@@ -3797,9 +3797,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						}
 					}
@@ -3814,9 +3814,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"slide": "1.1.6"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
 					}
 				},
 				"y18n": {
@@ -3834,18 +3834,18 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cliui": "4.1.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "9.0.2"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -3863,9 +3863,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"string-width": "2.1.1",
-								"strip-ansi": "4.0.0",
-								"wrap-ansi": "2.1.0"
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
 							}
 						},
 						"strip-ansi": {
@@ -3873,7 +3873,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						},
 						"yargs-parser": {
@@ -3881,7 +3881,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"camelcase": "4.1.0"
+								"camelcase": "^4.1.0"
 							}
 						}
 					}
@@ -3891,7 +3891,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -3915,7 +3915,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"onetime": {
@@ -3924,7 +3924,7 @@
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "1.2.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"optionator": {
@@ -3933,12 +3933,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
 			}
 		},
 		"os-locale": {
@@ -3947,9 +3947,9 @@
 			"integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
 			"dev": true,
 			"requires": {
-				"execa": "0.7.0",
-				"lcid": "1.0.0",
-				"mem": "1.1.0"
+				"execa": "^0.7.0",
+				"lcid": "^1.0.0",
+				"mem": "^1.1.0"
 			}
 		},
 		"os-tmpdir": {
@@ -3970,7 +3970,7 @@
 			"integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
 			"dev": true,
 			"requires": {
-				"p-try": "1.0.0"
+				"p-try": "^1.0.0"
 			}
 		},
 		"p-locate": {
@@ -3979,7 +3979,7 @@
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "1.3.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-try": {
@@ -3994,8 +3994,8 @@
 			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"dev": true,
 			"requires": {
-				"error-ex": "1.3.2",
-				"json-parse-better-errors": "1.0.2"
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
 			}
 		},
 		"path-exists": {
@@ -4037,7 +4037,7 @@
 			"integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
 			"dev": true,
 			"requires": {
-				"pify": "3.0.0"
+				"pify": "^3.0.0"
 			}
 		},
 		"pathval": {
@@ -4087,9 +4087,9 @@
 			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "4.0.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "3.0.0"
+				"load-json-file": "^4.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^3.0.0"
 			}
 		},
 		"readable-stream": {
@@ -4098,10 +4098,10 @@
 			"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
 			"dev": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.1",
 				"isarray": "0.0.1",
-				"string_decoder": "0.10.31"
+				"string_decoder": "~0.10.x"
 			}
 		},
 		"reflect-metadata": {
@@ -4122,7 +4122,7 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "1.0.2"
+				"is-finite": "^1.0.0"
 			}
 		},
 		"require-directory": {
@@ -4143,7 +4143,7 @@
 			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
 			"dev": true,
 			"requires": {
-				"path-parse": "1.0.6"
+				"path-parse": "^1.0.5"
 			}
 		},
 		"restore-cursor": {
@@ -4152,8 +4152,8 @@
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"dev": true,
 			"requires": {
-				"onetime": "2.0.1",
-				"signal-exit": "3.0.2"
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"rimraf": {
@@ -4162,7 +4162,7 @@
 			"integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2"
+				"glob": "^7.0.5"
 			}
 		},
 		"run-async": {
@@ -4171,7 +4171,7 @@
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"dev": true,
 			"requires": {
-				"is-promise": "2.1.0"
+				"is-promise": "^2.1.0"
 			}
 		},
 		"rx": {
@@ -4192,7 +4192,7 @@
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 			"dev": true,
 			"requires": {
-				"rx-lite": "4.0.8"
+				"rx-lite": "*"
 			}
 		},
 		"rxjs": {
@@ -4240,7 +4240,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -4261,13 +4261,13 @@
 			"integrity": "sha1-QnrjEqM308UWgEzidU6MDVAoywQ=",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "2.0.0",
-				"diff": "3.5.0",
-				"lodash.get": "4.4.2",
-				"lolex": "2.7.4",
-				"nise": "1.4.4",
-				"supports-color": "5.5.0",
-				"type-detect": "4.0.8"
+				"@sinonjs/formatio": "^2.0.0",
+				"diff": "^3.1.0",
+				"lodash.get": "^4.4.2",
+				"lolex": "^2.2.0",
+				"nise": "^1.2.0",
+				"supports-color": "^5.1.0",
+				"type-detect": "^4.0.5"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -4276,7 +4276,7 @@
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -4293,8 +4293,8 @@
 			"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "1.1.1",
-				"source-map": "0.6.1"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"spawn-command": {
@@ -4309,8 +4309,8 @@
 			"integrity": "sha1-BaW01xU6GVvJLDxCW2nzsqlSTII=",
 			"dev": true,
 			"requires": {
-				"spdx-expression-parse": "3.0.0",
-				"spdx-license-ids": "3.0.1"
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-exceptions": {
@@ -4325,8 +4325,8 @@
 			"integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
 			"dev": true,
 			"requires": {
-				"spdx-exceptions": "2.1.0",
-				"spdx-license-ids": "3.0.1"
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-license-ids": {
@@ -4347,10 +4347,10 @@
 			"integrity": "sha1-1DW9WXQ3Or2b2QaDWVEwhRBswF8=",
 			"dev": true,
 			"requires": {
-				"date-format": "0.0.0",
-				"debug": "0.7.4",
-				"mkdirp": "0.5.1",
-				"readable-stream": "1.1.14"
+				"date-format": "^0.0.0",
+				"debug": "^0.7.2",
+				"mkdirp": "^0.5.1",
+				"readable-stream": "^1.1.7"
 			},
 			"dependencies": {
 				"debug": {
@@ -4367,8 +4367,8 @@
 			"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0",
-				"strip-ansi": "4.0.0"
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
 			}
 		},
 		"string_decoder": {
@@ -4383,7 +4383,7 @@
 			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "3.0.0"
+				"ansi-regex": "^3.0.0"
 			}
 		},
 		"strip-bom": {
@@ -4404,24 +4404,24 @@
 			"integrity": "sha1-XZ0wymAvD6ClG3IPdKCRmgRlBZk=",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"commander": "2.18.0",
-				"escodegen": "1.11.0",
-				"esprima": "2.7.3",
-				"glob": "7.1.2",
-				"inquirer": "3.3.0",
-				"istanbul-lib-instrument": "1.10.2",
-				"lodash": "4.17.11",
-				"log4js": "1.1.1",
-				"mkdirp": "0.5.1",
-				"mz": "2.7.0",
-				"prettier": "1.14.2",
-				"progress": "2.0.0",
-				"rimraf": "2.6.2",
-				"rxjs": "5.5.12",
-				"serialize-javascript": "1.5.0",
-				"tslib": "1.9.3",
-				"typed-rest-client": "0.10.0"
+				"chalk": "^2.3.0",
+				"commander": "^2.12.2",
+				"escodegen": "^1.8.0",
+				"esprima": "^2.7.0",
+				"glob": "^7.0.3",
+				"inquirer": "^3.0.6",
+				"istanbul-lib-instrument": "^1.9.1",
+				"lodash": "^4.17.4",
+				"log4js": "^1.1.0",
+				"mkdirp": "^0.5.1",
+				"mz": "^2.6.0",
+				"prettier": "^1.6.1",
+				"progress": "^2.0.0",
+				"rimraf": "^2.6.1",
+				"rxjs": "^5.4.3",
+				"serialize-javascript": "^1.3.0",
+				"tslib": "^1.5.0",
+				"typed-rest-client": "^0.10.0"
 			},
 			"dependencies": {
 				"commander": {
@@ -4438,7 +4438,7 @@
 			"integrity": "sha1-6erYwfK7IobVNTGY6zvL4avqtPs=",
 			"dev": true,
 			"requires": {
-				"tslib": "1.9.3"
+				"tslib": "^1.6.0"
 			}
 		},
 		"stryker-html-reporter": {
@@ -4447,13 +4447,13 @@
 			"integrity": "sha1-N+o7bKAZc1/cyrYVlbEjXlOEPiY=",
 			"dev": true,
 			"requires": {
-				"file-url": "2.0.2",
-				"lodash": "4.17.11",
-				"log4js": "1.1.1",
-				"mkdirp": "0.5.1",
-				"mz": "2.7.0",
-				"rimraf": "2.6.2",
-				"typed-html": "0.6.0"
+				"file-url": "^2.0.0",
+				"lodash": "^4.13.1",
+				"log4js": "^1.0.1",
+				"mkdirp": "^0.5.1",
+				"mz": "^2.5.0",
+				"rimraf": "^2.6.1",
+				"typed-html": "^0.6.0"
 			}
 		},
 		"stryker-mocha-framework": {
@@ -4462,7 +4462,7 @@
 			"integrity": "sha1-K1hC2pBnMhO5RuMzoTPbnZaYxb0=",
 			"dev": true,
 			"requires": {
-				"log4js": "1.1.1"
+				"log4js": "^1.1.1"
 			}
 		},
 		"stryker-mocha-runner": {
@@ -4471,8 +4471,8 @@
 			"integrity": "sha1-wcKp2WilMCJn0SeTMmDyLDetYf8=",
 			"dev": true,
 			"requires": {
-				"log4js": "1.1.1",
-				"tslib": "1.9.3"
+				"log4js": "^1.1.1",
+				"tslib": "^1.5.0"
 			}
 		},
 		"stryker-typescript": {
@@ -4481,11 +4481,11 @@
 			"integrity": "sha1-nndQ4IJiRPvfjkHvMTARpa/PkY8=",
 			"dev": true,
 			"requires": {
-				"lodash.flatmap": "4.5.0",
-				"log4js": "1.1.1",
-				"semver": "5.5.1",
-				"source-map": "0.5.7",
-				"tslib": "1.9.3"
+				"lodash.flatmap": "^4.5.0",
+				"log4js": "^1.1.1",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.6",
+				"tslib": "^1.5.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -4502,7 +4502,7 @@
 			"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 			"dev": true,
 			"requires": {
-				"has-flag": "1.0.0"
+				"has-flag": "^1.0.0"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -4531,7 +4531,7 @@
 			"integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
 			"dev": true,
 			"requires": {
-				"any-promise": "1.3.0"
+				"any-promise": "^1.0.0"
 			}
 		},
 		"thenify-all": {
@@ -4540,7 +4540,7 @@
 			"integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
 			"dev": true,
 			"requires": {
-				"thenify": "3.3.0"
+				"thenify": ">= 3.1.0 < 4"
 			}
 		},
 		"through": {
@@ -4555,7 +4555,7 @@
 			"integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "1.0.2"
+				"os-tmpdir": "~1.0.2"
 			}
 		},
 		"to-fast-properties": {
@@ -4582,14 +4582,14 @@
 			"integrity": "sha1-ZaCuKszjGepP16yNfJ8fkMXaa68=",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"buffer-from": "1.1.1",
-				"diff": "3.5.0",
-				"make-error": "1.3.5",
-				"minimist": "1.2.0",
-				"mkdirp": "0.5.1",
-				"source-map-support": "0.5.9",
-				"yn": "2.0.0"
+				"arrify": "^1.0.0",
+				"buffer-from": "^1.1.0",
+				"diff": "^3.1.0",
+				"make-error": "^1.1.1",
+				"minimist": "^1.2.0",
+				"mkdirp": "^0.5.1",
+				"source-map-support": "^0.5.6",
+				"yn": "^2.0.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -4612,18 +4612,18 @@
 			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"builtin-modules": "1.1.1",
-				"chalk": "2.4.1",
-				"commander": "2.18.0",
-				"diff": "3.5.0",
-				"glob": "7.1.2",
-				"js-yaml": "3.12.0",
-				"minimatch": "3.0.4",
-				"resolve": "1.8.1",
-				"semver": "5.5.1",
-				"tslib": "1.9.3",
-				"tsutils": "2.29.0"
+				"babel-code-frame": "^6.22.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^3.2.0",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.7.0",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.27.2"
 			},
 			"dependencies": {
 				"commander": {
@@ -4640,9 +4640,9 @@
 			"integrity": "sha512-o2FhaQtxXi6FQ1v0T2n/rACNos6PhuKRmvemMpWxI+9NJn2OOlJ3+OtEmnCdoF7GPXT3Eyk+Q0q4P96flrPl3w==",
 			"dev": true,
 			"requires": {
-				"tslint-consistent-codestyle": "1.13.3",
-				"tslint-eslint-rules": "5.4.0",
-				"tslint-microsoft-contrib": "5.2.1"
+				"tslint-consistent-codestyle": "^1.13.3",
+				"tslint-eslint-rules": "^5.4.0",
+				"tslint-microsoft-contrib": "~5.2.0"
 			}
 		},
 		"tslint-consistent-codestyle": {
@@ -4651,9 +4651,9 @@
 			"integrity": "sha512-+ocXSNGHqUCUyTJsPhS7xqcC3qf6FyP4vd1jEaXaWaJ5NNN36gKZhqNt3nAWH/YgSV0tYaapjSWMbJQJmn/5MQ==",
 			"dev": true,
 			"requires": {
-				"@fimbul/bifrost": "0.11.0",
-				"tslib": "1.9.3",
-				"tsutils": "2.29.0"
+				"@fimbul/bifrost": "^0.11.0",
+				"tslib": "^1.7.1",
+				"tsutils": "^2.27.0"
 			}
 		},
 		"tslint-eslint-rules": {
@@ -4664,7 +4664,7 @@
 			"requires": {
 				"doctrine": "0.7.2",
 				"tslib": "1.9.0",
-				"tsutils": "3.0.0"
+				"tsutils": "^3.0.0"
 			},
 			"dependencies": {
 				"tslib": {
@@ -4679,7 +4679,7 @@
 					"integrity": "sha512-LjHBWR0vWAUHWdIAoTjoqi56Kz+FDKBgVEuL+gVPG/Pv7QW5IdaDDeK9Txlr6U0Cmckp5EgCIq1T25qe3J6hyw==",
 					"dev": true,
 					"requires": {
-						"tslib": "1.9.0"
+						"tslib": "^1.8.1"
 					}
 				}
 			}
@@ -4690,7 +4690,7 @@
 			"integrity": "sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==",
 			"dev": true,
 			"requires": {
-				"tsutils": "2.28.0"
+				"tsutils": "^2.27.2 <2.29.0"
 			},
 			"dependencies": {
 				"tsutils": {
@@ -4699,7 +4699,7 @@
 					"integrity": "sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==",
 					"dev": true,
 					"requires": {
-						"tslib": "1.9.3"
+						"tslib": "^1.8.1"
 					}
 				}
 			}
@@ -4710,7 +4710,7 @@
 			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
 			"dev": true,
 			"requires": {
-				"tslib": "1.9.3"
+				"tslib": "^1.8.1"
 			}
 		},
 		"tunnel": {
@@ -4725,7 +4725,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2"
+				"prelude-ls": "~1.1.2"
 			}
 		},
 		"type-detect": {
@@ -4751,9 +4751,9 @@
 			}
 		},
 		"typescript": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha1-HL9h0F1rliaSROtqO85L2RTg8Aw=",
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.4.tgz",
+			"integrity": "sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==",
 			"dev": true
 		},
 		"underscore": {
@@ -4768,8 +4768,8 @@
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "3.0.0",
-				"spdx-expression-parse": "3.0.0"
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"which": {
@@ -4778,7 +4778,7 @@
 			"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
 			"dev": true,
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"which-module": {
@@ -4799,8 +4799,8 @@
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4815,7 +4815,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"string-width": {
@@ -4824,9 +4824,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -4835,7 +4835,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				}
 			}
@@ -4864,18 +4864,18 @@
 			"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 			"dev": true,
 			"requires": {
-				"cliui": "4.1.0",
-				"decamelize": "1.2.0",
-				"find-up": "2.1.0",
-				"get-caller-file": "1.0.3",
-				"os-locale": "2.1.0",
-				"require-directory": "2.1.1",
-				"require-main-filename": "1.0.1",
-				"set-blocking": "2.0.0",
-				"string-width": "2.1.1",
-				"which-module": "2.0.0",
-				"y18n": "3.2.1",
-				"yargs-parser": "9.0.2"
+				"cliui": "^4.0.0",
+				"decamelize": "^1.1.1",
+				"find-up": "^2.1.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^2.0.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1",
+				"yargs-parser": "^9.0.2"
 			}
 		},
 		"yargs-parser": {
@@ -4884,7 +4884,7 @@
 			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "4.1.0"
+				"camelcase": "^4.1.0"
 			}
 		},
 		"yn": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
 		"ts-node": "^6.0.1",
 		"tslint": "^5.9.1",
 		"tslint-config-airbnb": "^5.8.0",
-		"typescript": "^2.7.2"
+		"typescript": "^2.8.4"
 	},
 	"nyc": {
 		"include": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.8.0",
+	"version": "1.9.0-develop.0",
 	"description": "A client for interacting with ChannelApe's API",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/RequestClientWrapper.ts
+++ b/src/RequestClientWrapper.ts
@@ -49,6 +49,17 @@ export default class RequestClientWrapper {
     );
   }
 
+  public patch(url: string, params: AxiosRequestConfig, callback: RequestCallback): void {
+    this.makeRequest(
+      HttpRequestMethod.PATCH,
+      new Date(),
+      0,
+      url,
+      params,
+      callback
+    );
+  }
+
   public post(url: string, params: AxiosRequestConfig, callback: RequestCallback): void {
     this.makeRequest(
       HttpRequestMethod.POST,
@@ -93,6 +104,10 @@ export default class RequestClientWrapper {
         case HttpRequestMethod.POST:
           const postData = options.data === undefined ? '' : options.data;
           requestPromise = axios.post(url, { body: postData }, options);
+          break;
+        case HttpRequestMethod.PATCH:
+          const patchData = options.data === undefined ? '' : options.data;
+          requestPromise = axios.patch(url, { body: patchData }, options);
           break;
         default:
           throw new ChannelApeError('HTTP Request Method could not be determined', {} as any, '', []);

--- a/src/model/HttpRequestMethod.ts
+++ b/src/model/HttpRequestMethod.ts
@@ -1,6 +1,7 @@
 enum HttpRequestMethod {
   GET = 'GET',
   PUT = 'PUT',
-  POST = 'POST'
+  POST = 'POST',
+  PATCH = 'PATCH'
 }
 export default HttpRequestMethod;

--- a/src/model/RecursivePartial.ts
+++ b/src/model/RecursivePartial.ts
@@ -1,0 +1,6 @@
+export type RecursivePartial<T> = {
+  [P in keyof T]?:
+    T[P] extends (infer U)[] ? RecursivePartial<U>[] :
+    T[P] extends object ? RecursivePartial<T[P]> :
+    T[P];
+};

--- a/src/model/RecursivePartial.ts
+++ b/src/model/RecursivePartial.ts
@@ -1,6 +1,0 @@
-export type RecursivePartial<T> = {
-  [P in keyof T]?:
-    T[P] extends (infer U)[] ? RecursivePartial<U>[] :
-    T[P] extends object ? RecursivePartial<T[P]> :
-    T[P];
-};

--- a/src/orders/model/OrderPatchRequest.ts
+++ b/src/orders/model/OrderPatchRequest.ts
@@ -1,6 +1,6 @@
 import Order from './Order';
-import { RecursivePartial } from '../../model/RecursivePartial';
 
-export default interface OrderPatchRequest extends RecursivePartial<Order> {
+export default interface OrderPatchRequest extends Partial<Order> {
   actionId?: string;
+  channelSync?: boolean;
 }

--- a/src/orders/model/OrderPatchRequest.ts
+++ b/src/orders/model/OrderPatchRequest.ts
@@ -1,0 +1,6 @@
+import Order from './Order';
+import { RecursivePartial } from '../../model/RecursivePartial';
+
+export default interface OrderPatchRequest extends RecursivePartial<Order> {
+  actionId?: string;
+}

--- a/src/orders/model/OrderUpdateRequest.ts
+++ b/src/orders/model/OrderUpdateRequest.ts
@@ -2,4 +2,5 @@ import Order from './Order';
 
 export default interface OrderUpdateRequest extends Order {
   actionId?: string;
+  channelSync?: boolean;
 }

--- a/src/orders/service/OrdersCrudService.ts
+++ b/src/orders/service/OrdersCrudService.ts
@@ -17,6 +17,7 @@ import RequestCallbackParams from '../../model/RequestCallbackParams';
 import GenerateApiError from '../../utils/GenerateApiError';
 import * as Q from 'q';
 import GenericOrdersQueryRequest from './model/GenericOrdersQueryRequest';
+import OrderPatchRequest from '../model/OrderPatchRequest';
 
 const EXPECTED_GET_STATUS = 200;
 const EXPECTED_CREATE_STATUS = 202;
@@ -63,6 +64,23 @@ export default class OrdersCrudService {
       };
     }
     this.client.put(requestUrl, options, (error, response, body) => {
+      this.mapOrderPromise(requestUrl, deferred, error, response, body, EXPECTED_UPDATE_STATUS);
+    });
+    return deferred.promise as any;
+  }
+
+  public patch(order: OrderPatchRequest): Promise<Order> {
+    const deferred = Q.defer<Order>();
+    const requestUrl = `${Version.V1}${Resource.ORDERS}/${order.id}`;
+    const options: AxiosRequestConfig = {
+      data: order
+    };
+    if (order.actionId) {
+      options.headers = {
+        'X-Channel-Ape-Action-Id': order.actionId
+      };
+    }
+    this.client.patch(requestUrl, options, (error, response, body) => {
       this.mapOrderPromise(requestUrl, deferred, error, response, body, EXPECTED_UPDATE_STATUS);
     });
     return deferred.promise as any;

--- a/src/orders/service/OrdersService.ts
+++ b/src/orders/service/OrdersService.ts
@@ -9,6 +9,7 @@ import OrderActivitiesService from './activities/OrderActivitiesService';
 import RequestClientWrapper from '../../RequestClientWrapper';
 import GenericOrdersQueryRequest from './model/GenericOrdersQueryRequest';
 import OrdersCrudService from './OrdersCrudService';
+import OrderPatchRequest from '../model/OrderPatchRequest';
 
 export default class OrdersService {
   private readonly ordersCrudService: OrdersCrudService;
@@ -41,6 +42,10 @@ export default class OrdersService {
 
   public update(order: OrderUpdateRequest): Promise<Order> {
     return this.ordersCrudService.update(order);
+  }
+
+  public patch(order: OrderPatchRequest): Promise<Order> {
+    return this.ordersCrudService.patch(order);
   }
 
   public create(order: OrderCreateRequest): Promise<Order> {

--- a/test/model/HttpRequestMethod.spec.ts
+++ b/test/model/HttpRequestMethod.spec.ts
@@ -11,4 +11,7 @@ describe('HttpRequestMethod', () => {
   it('POST', () => {
     expect(HttpRequestMethod.POST).to.equal('POST');
   });
+  it('PATCH', () => {
+    expect(HttpRequestMethod.PATCH).to.equal('PATCH');
+  });
 });

--- a/test/orders/resources/singleOrderToPatch.ts
+++ b/test/orders/resources/singleOrderToPatch.ts
@@ -1,0 +1,188 @@
+import Order from '../../../src/orders/model/Order';
+import OrderStatus from '../../../src/orders/model/OrderStatus';
+
+const singleOrderToPatch: Partial<Order> = {
+  additionalFields: [
+    {
+      name: 'note_attributes_order_type',
+      value: 'CC'
+    },
+    {
+      name: 'note_attributes_customerAccount',
+      value: 'Rogue'
+    },
+    {
+      name: 'closed_at',
+      value: 'null'
+    },
+    {
+      name: 'number',
+      value: '572'
+    },
+    {
+      name: 'number',
+      value: '666'
+    },
+    {
+      name: 'token',
+      value: 'b9b9:1eaa:e69d:cac8:1a9a:ed6c:753d:764b'
+    },
+    {
+      name: 'taxes_included',
+      value: 'false'
+    },
+    {
+      name: 'financial_status',
+      value: 'paid'
+    },
+    {
+      name: 'total_discounts',
+      value: '0.00'
+    },
+    {
+      name: 'total_line_items_price',
+      value: '10.43'
+    },
+    {
+      name: 'cart_token',
+      value: '43feecf3fb62dd68b468e204f60e1b6a'
+    },
+    {
+      name: 'buyer_accepts_marketing',
+      value: 'false'
+    },
+    {
+      name: 'name',
+      value: 'InsB15728169'
+    },
+    {
+      name: 'referring_site',
+      value: 'darrick.net'
+    },
+    {
+      name: 'landing_site',
+      value: 'valentine.name'
+    },
+    {
+      name: 'cancelled_at',
+      value: 'null'
+    },
+    {
+      name: 'user_id',
+      value: 'null'
+    },
+    {
+      name: 'location_id',
+      value: 'null'
+    },
+    {
+      name: 'browser_ip',
+      value: '172.8.239.51'
+    },
+    {
+      name: 'order_number',
+      value: '1572'
+    },
+    {
+      name: 'processing_method',
+      value: 'direct'
+    },
+    {
+      name: 'source_name',
+      value: 'web'
+    },
+    {
+      name: 'fulfillment_status',
+      value: 'fulfilled'
+    },
+    {
+      name: 'tags',
+      value: 'InProcess'
+    },
+    {
+      name: 'order_status_url',
+      value: 'paris.com'
+    },
+    {
+      name: 'risk_recommendation',
+      value: 'accept'
+    },
+    {
+      name: 'risk_message',
+      value: 'Billing street address is correct'
+    },
+    {
+      name: 'risk_merchant_message',
+      value: 'Billing street address is correct'
+    }
+  ],
+  alphabeticCurrencyCode: 'USD',
+  businessId: '23aac9ff-d9f3-4b80-bf5a-8d438111a222',
+  channelId: '0d134d16-ad7e-4724-841e-7d46e0f128bd',
+  channelOrderId: '314980073478',
+  createdAt: new Date('2018-05-03T18:07:58.009Z'),
+  customer: {
+    additionalFields: [
+      {
+        name: 'id',
+        value: '197323554842'
+      },
+      {
+        name: 'accepts_marketing',
+        value: 'false'
+      },
+      {
+        name: 'orders_count',
+        value: '1'
+      },
+      {
+        name: 'total_spent',
+        value: '14.42'
+      },
+      {
+        name: 'state',
+        value: 'disabled'
+      }
+    ],
+    billingAddress: {
+      additionalFields: [],
+      address1: '93414 Kaci Tunnel',
+      city: 'Gleichnerville',
+      country: 'United States',
+      countryCode: 'US',
+      firstName: 'Axel',
+      lastName: 'Herzog',
+      name: 'Axel Herzog',
+      postalCode: '15454-7009',
+      provinceCode: 'PA',
+      province: 'New Hampshire'
+    },
+    email: 'Damaris_Walsh88@hotmail.com',
+    firstName: 'Axel',
+    lastName: 'Herzog',
+    shippingAddress: {
+      additionalFields: [],
+      address1: '93414 Kaci Tunnel',
+      city: 'Gleichnerville',
+      country: 'United States',
+      countryCode: 'US',
+      firstName: 'Axel',
+      lastName: 'Herzog',
+      name: 'Axel Herzog',
+      postalCode: '15454-7009',
+      provinceCode: 'PA',
+      province: 'New Hampshire'
+    }
+  },
+  fulfillments: [],
+  id: 'c0f45529-cbed-4e90-9a38-c208d409ef2a',
+  purchasedAt: new Date('2018-03-29T19:06:26.000Z'),
+  status: OrderStatus.OPEN,
+  subtotalPrice: 41.72,
+  totalGrams: 476,
+  totalPrice: 43.99,
+  totalTax: 0.00,
+  updatedAt: new Date('2018-05-03T18:07:58.009Z')
+};
+
+export default singleOrderToPatch;

--- a/test/orders/resources/singleOrderToPatchResponse.ts
+++ b/test/orders/resources/singleOrderToPatchResponse.ts
@@ -1,0 +1,415 @@
+export default {
+  additionalFields: [
+    {
+      name: 'note_attributes_order_type',
+      value: 'TT'
+    },
+    {
+      name: 'note_attributes_customerAccount',
+      value: 'Rogue'
+    },
+    {
+      name: 'closed_at',
+      value: 'null'
+    },
+    {
+      name: 'number',
+      value: '572'
+    },
+    {
+      name: 'number',
+      value: '666'
+    },
+    {
+      name: 'token',
+      value: 'b9b9:1eaa:e69d:cac8:1a9a:ed6c:753d:764b'
+    },
+    {
+      name: 'taxes_included',
+      value: 'false'
+    },
+    {
+      name: 'financial_status',
+      value: 'paid'
+    },
+    {
+      name: 'total_discounts',
+      value: '0.00'
+    },
+    {
+      name: 'total_line_items_price',
+      value: '10.43'
+    },
+    {
+      name: 'cart_token',
+      value: '43feecf3fb62dd68b468e204f60e1b6a'
+    },
+    {
+      name: 'buyer_accepts_marketing',
+      value: 'false'
+    },
+    {
+      name: 'name',
+      value: 'InsB15728169'
+    },
+    {
+      name: 'referring_site',
+      value: 'darrick.net'
+    },
+    {
+      name: 'landing_site',
+      value: 'valentine.name'
+    },
+    {
+      name: 'cancelled_at',
+      value: 'null'
+    },
+    {
+      name: 'user_id',
+      value: 'null'
+    },
+    {
+      name: 'location_id',
+      value: 'null'
+    },
+    {
+      name: 'browser_ip',
+      value: '172.8.239.51'
+    },
+    {
+      name: 'order_number',
+      value: '1572'
+    },
+    {
+      name: 'processing_method',
+      value: 'direct'
+    },
+    {
+      name: 'source_name',
+      value: 'web'
+    },
+    {
+      name: 'fulfillment_status',
+      value: 'fulfilled'
+    },
+    {
+      name: 'tags',
+      value: 'InProcess'
+    },
+    {
+      name: 'order_status_url',
+      value: 'paris.com'
+    },
+    {
+      name: 'risk_recommendation',
+      value: 'accept'
+    },
+    {
+      name: 'risk_message',
+      value: 'Billing street address is correct'
+    },
+    {
+      name: 'risk_merchant_message',
+      value: 'Billing street address is correct'
+    }
+  ],
+  alphabeticCurrencyCode: 'USD',
+  businessId: '4d688534-d82e-4111-940c-322ba9aec108',
+  channelId: '0d134d16-ad7e-4724-841e-7d46e0f128bd',
+  channelOrderId: '314980073478',
+  createdAt: '2018-05-03T18:07:58.009Z',
+  customer: {
+    additionalFields: [
+      {
+        name: 'id',
+        value: '197323554842'
+      },
+      {
+        name: 'accepts_marketing',
+        value: 'false'
+      },
+      {
+        name: 'orders_count',
+        value: '1'
+      },
+      {
+        name: 'total_spent',
+        value: '14.42'
+      },
+      {
+        name: 'state',
+        value: 'disabled'
+      }
+    ],
+    billingAddress: {
+      additionalFields: [],
+      address1: '93414 Kaci Tunnel',
+      city: 'Gleichnerville',
+      country: 'United States',
+      countryCode: 'US',
+      firstName: 'Axel',
+      lastName: 'Herzog',
+      name: 'Axel Herzog',
+      postalCode: '15454-7009',
+      province: 'Pennsylvania',
+      provinceCode: 'PA'
+    },
+    email: 'Damaris_Walsh88@hotmail.com',
+    firstName: 'Axel',
+    lastName: 'Herzog',
+    shippingAddress: {
+      additionalFields: [],
+      address1: '123 Test Lane',
+      city: 'Fargo',
+      country: 'United States',
+      countryCode: 'US',
+      firstName: 'Axel',
+      lastName: 'Herzog',
+      name: 'Axel Herzog',
+      postalCode: '15454-7009',
+      province: 'North Dakota',
+      provinceCode: 'PA'
+    }
+  },
+  errors: [],
+  fulfillments: [
+    {
+      additionalFields: [
+        {
+          name: 'some-addtl-field',
+          value: 'some-value'
+        }
+      ],
+      id: 's',
+      lineItems: [
+        {
+          additionalFields: [
+            {
+              name: 'variant_id',
+              value: '36581474886'
+            },
+            {
+              name: 'title',
+              value: 'Ergonomic Plastic Computer'
+            },
+            {
+              name: 'variant_title',
+              value: 'Ergonomic Plastic Computer'
+            },
+            {
+              name: 'product_id',
+              value: '9670311622'
+            },
+            {
+              name: 'requires_shipping',
+              value: 'true'
+            },
+            {
+              name: 'taxable',
+              value: 'true'
+            },
+            {
+              name: 'gift_card',
+              value: 'false'
+            },
+            {
+              name: 'variant_inventory_management',
+              value: 'shopify'
+            },
+            {
+              name: 'fulfillable_quantity',
+              value: '1'
+            },
+            {
+              name: 'total_discount',
+              value: '0.00'
+            },
+            {
+              name: 'fulfillment_service',
+              value: 'manual'
+            }
+          ],
+          grams: '371',
+          id: '646495567878',
+          price: '12.99',
+          quantity: 1,
+          shippingMethod: 'Standard',
+          sku: 'b4809155-1c5d-4b3b-affc-491ad5503007',
+          title: 'Ergonomic Plastic Computer',
+          vendor: 'Greenholt Group'
+        },
+        {
+          additionalFields: [
+            {
+              name: 'variant_id',
+              value: '42852035782'
+            },
+            {
+              name: 'title',
+              value: 'Tasty Cotton Bike'
+            },
+            {
+              name: 'product_id',
+              value: '10590339974'
+            },
+            {
+              name: 'requires_shipping',
+              value: 'true'
+            },
+            {
+              name: 'taxable',
+              value: 'true'
+            },
+            {
+              name: 'gift_card',
+              value: 'false'
+            },
+            {
+              name: 'variant_inventory_management',
+              value: 'shopify'
+            },
+            {
+              name: 'fulfillable_quantity',
+              value: '1'
+            },
+            {
+              name: 'total_discount',
+              value: '0.00'
+            },
+            {
+              name: 'fulfillment_service',
+              value: 'manual'
+            }
+          ],
+          grams: '369',
+          id: '646495600646',
+          price: '12.99',
+          quantity: 1,
+          shippingMethod: 'Standard',
+          sku: 'fc4bad52-475e-4320-828e-00fc753244fe',
+          title: 'Tasty Cotton Bike',
+          vendor: 'Frami LLC'
+        }
+      ],
+      status: 'OPEN'
+    }
+  ],
+  id: 'c0f45529-cbed-4e90-9a38-c208d409ef2a',
+  lineItems: [
+    {
+      additionalFields: [
+        {
+          name: 'variant_id',
+          value: '36581474886'
+        },
+        {
+          name: 'title',
+          value: 'Generic Steel Shirt'
+        },
+        {
+          name: 'variant_title',
+          value: 'Generic Steel Shirt'
+        },
+        {
+          name: 'product_id',
+          value: '9670311622'
+        },
+        {
+          name: 'requires_shipping',
+          value: 'true'
+        },
+        {
+          name: 'taxable',
+          value: 'true'
+        },
+        {
+          name: 'gift_card',
+          value: 'false'
+        },
+        {
+          name: 'variant_inventory_management',
+          value: 'shopify'
+        },
+        {
+          name: 'fulfillable_quantity',
+          value: '1'
+        },
+        {
+          name: 'total_discount',
+          value: '0.00'
+        },
+        {
+          name: 'fulfillment_service',
+          value: 'manual'
+        }
+      ],
+      grams: '371',
+      id: '646495567878',
+      price: '12.99',
+      quantity: 1,
+      shippingMethod: 'Standard',
+      sku: 'e67f1d90-824a-4941-8497-08d632763c93',
+      title: 'Generic Steel Shirt',
+      vendor: 'Ankunding - Corwin'
+    },
+    {
+      additionalFields: [
+        {
+          name: 'variant_id',
+          value: '42852035782'
+        },
+        {
+          name: 'title',
+          value: 'Tasty Steel Bacon'
+        },
+        {
+          name: 'product_id',
+          value: '10590339974'
+        },
+        {
+          name: 'requires_shipping',
+          value: 'true'
+        },
+        {
+          name: 'taxable',
+          value: 'true'
+        },
+        {
+          name: 'gift_card',
+          value: 'false'
+        },
+        {
+          name: 'variant_inventory_management',
+          value: 'shopify'
+        },
+        {
+          name: 'fulfillable_quantity',
+          value: '1'
+        },
+        {
+          name: 'total_discount',
+          value: '0.00'
+        },
+        {
+          name: 'fulfillment_service',
+          value: 'manual'
+        }
+      ],
+      grams: '369',
+      id: '646495600646',
+      price: '12.99',
+      quantity: 1,
+      shippingMethod: 'Standard',
+      sku: '27464759-a723-47bf-8d31-332cec285ead',
+      title: 'Tasty Steel Bacon',
+      vendor: 'Hand, Swift and Langosh'
+    }
+  ],
+  purchasedAt: '2018-03-29T19:06:26.000Z',
+  status: 'OPEN',
+  subtotalPrice: '41.72',
+  totalGrams: '476',
+  totalPrice: '43.99',
+  totalTax: '0.00',
+  updatedAt: '2018-05-07T18:48:06.839Z'
+};

--- a/test/orders/service/OrdersService.spec.ts
+++ b/test/orders/service/OrdersService.spec.ts
@@ -25,7 +25,6 @@ import singleOrderToUpdateResponse from '../resources/singleOrderToUpdateRespons
 import multipleOrders from '../resources/multipleOrders';
 import singleOrderToPatchResponse from '../resources/singleOrderToPatchResponse';
 import singleOrderToPatch from '../resources/singleOrderToPatch';
-import { RecursivePartial } from '../../../src/model/RecursivePartial';
 
 const maximumRequestRetryTimeout = 3000;
 
@@ -353,7 +352,7 @@ Code: 15 Message: Requested business cannot be found.`;
       const newAddress1 = '123 Test Lane';
       const newProvince = 'North Dakota';
 
-      const order: RecursivePartial<OrderPatchRequest> = JSON.parse(JSON.stringify(singleOrderToPatch));
+      const order: OrderPatchRequest = JSON.parse(JSON.stringify(singleOrderToPatch));
       order.id = 'c0f45529-cbed-4e90-9a38-c208d409ef2a';
       order.actionId = 'some-action-id';
       order.customer = {
@@ -385,7 +384,7 @@ Code: 15 Message: Requested business cannot be found.`;
       const newAddress1 = '123 Test Lane';
       const newProvince = 'North Dakota';
 
-      const order: RecursivePartial<OrderPatchRequest> = JSON.parse(JSON.stringify(singleOrderToPatch));
+      const order: OrderPatchRequest = JSON.parse(JSON.stringify(singleOrderToPatch));
       order.id = 'c0f45529-cbed-4e90-9a38-c208d409ef2a';
       order.customer = {
         shippingAddress: {


### PR DESCRIPTION
Added ability to patch an order and any of its child properties (i.e. customer, shipping address).  `patch()` is similar to the `update()` method, except it accepts a partial order object.

No known drawbacks.