### PR TITLE
CA-5380 Catching all network errors during retry attempts

### DIFF
--- a/src/RequestClientWrapper.ts
+++ b/src/RequestClientWrapper.ts
@@ -209,7 +209,7 @@ export default class RequestClientWrapper {
     response: AxiosResponse | undefined,
     code?: string
   ): boolean {
-    if (code && (code === 'ECONNABORTED' || code === 'Network Error')) {
+    if (code) {
       return true;
     }
     if (response == null) {

--- a/test/variants/service/VariantService.spec.ts
+++ b/test/variants/service/VariantService.spec.ts
@@ -17,7 +17,7 @@ import VariantsSearchRequestByUpc from '../../../src/variants/model/VariantsSear
 import VariantsSearchRequestByProductFilterId from '../../../src/variants/model/VariantsSearchRequestByProductFilterId';
 import VariantSearchDetails from '../../../src/variants/model/VariantSearchDetails';
 
-const maximumRequestRetryTimeout = 50;
+const maximumRequestRetryTimeout = 300;
 
 const quickSearchByProductFilterIdResults = [
   JSON.parse(fs.readFileSync(


### PR DESCRIPTION
Previously when determining if a failed request should be retried, we were only retrying `ECONNABORTED` and `Network Error` error codes.  However there were certain other error codes which weren't being retried: `ECONNREFUSED`, `ECONNRESET`, `ENOTFOUND`.

We now will retry every network error code.