### PR TITLE
CA-5464 Fixed uncaught exception bug

### DIFF
--- a/src/RequestClientWrapper.ts
+++ b/src/RequestClientWrapper.ts
@@ -188,6 +188,7 @@ export default class RequestClientWrapper {
     try {
       callback(finalError, requestResponse.response as any, requestResponse.body);
     } catch (e) {
+      callback(new Error('API Error'), e, {});
       this.requestLogger.logCallbackError(e);
     }
   }

--- a/src/service/RestService.ts
+++ b/src/service/RestService.ts
@@ -14,7 +14,7 @@ export default abstract class RestService {
     expectedStatusCode: number
   ): void {
     if (error) {
-      throw error;
+      deferred.reject(error);
     } else if (response.status === expectedStatusCode) {
       deferred.resolve(body);
     } else {

--- a/test/inventories/service/InventoriesService.spec.ts
+++ b/test/inventories/service/InventoriesService.spec.ts
@@ -109,6 +109,29 @@ describe('Inventories Service', () => {
       }
     });
 
+    it('And inventory item id but ChannelApe API returns a 500' +
+      'When searching inventory items then return reject promise with errors', async () => {
+
+      const response = {
+        status: 500,
+        config: {
+          method: 'GET'
+        }
+      };
+
+      const clientGetStub: sinon.SinonStub = sandbox.stub(client, 'get')
+          .yields(response, null, expectedChannelApeErrorResponse);
+
+      const inventoriesService: InventoriesService = new InventoriesService(client);
+      try {
+        await inventoriesService.get('1');
+        fail('Successfully ran inventory retrieval by id but should have failed with 500');
+      } catch (error) {
+        expect(clientGetStub.args[0][0]).to.equal(`/${Version.V1}${Resource.INVENTORIES}/1`);
+        expect(error.status).to.equal(500);
+      }
+    });
+
     it('And exception is thrown' +
       'When searching inventory items then return reject promise with errors', async () => {
 


### PR DESCRIPTION
When a 500 level was returned from the API and could not resolve before the retry timeout, it now catches and gracefully rejects the error instead of throwing an uncaught exception.

This was only affecting services which extended the RestService to use the `mapResponseToPromise` method.