### PR TITLE
CA-5471 Adds support for purchase order number on orders and order queries

### DIFF
--- a/e2e/ChannelApeClient.spec.ts
+++ b/e2e/ChannelApeClient.spec.ts
@@ -7,6 +7,7 @@ import ChannelApeApiError from '../src/model/ChannelApeApiError';
 import ChannelApeClient from '../src/ChannelApeClient';
 import OrderStatus from '../src/orders/model/OrderStatus';
 import OrdersQueryRequestByBusinessId from '../src/orders/model/OrdersQueryRequestByBusinessId';
+import OrdersQueryRequestByPurchaseOrderNumber from '../src/orders/model/OrdersQueryRequestByPurchaseOrderNumber';
 import Channel from '../src/channels/model/Channel';
 import Supplier from '../src/suppliers/model/Supplier';
 import VariantsRequestByProductId from '../src/variants/model/VariantsRequestByProductId';
@@ -287,6 +288,7 @@ describe('ChannelApe Client', () => {
           const expectedFirstName = faker.name.firstName();
           const expectedLastName = faker.name.lastName();
           const expectedChannelOrderId = Math.random().toString();
+          const expectedPurchaseOrderNumber = Math.random().toString();
           const fullName = `${expectedFirstName} ${expectedLastName}`;
           const expectedLineItemQuantities = [
             faker.random.number(20) + 1,
@@ -308,6 +310,7 @@ describe('ChannelApe Client', () => {
               { name: 'name', value: `SDK${parseInt((Math.random() * 100000).toString(), 10).toString()}` },
               { name: 'order_number', value: parseInt((Math.random() * 100000).toString(), 10).toString() }
             ],
+            purchaseOrderNumber: expectedPurchaseOrderNumber,
             totalPrice: faker.random.number({ min: 1, max: 700, precision: 2 }),
             alphabeticCurrencyCode: 'USD',
             channelId: expectedChannelId,
@@ -336,6 +339,7 @@ describe('ChannelApe Client', () => {
           }
 
           return channelApeClient.orders().create(orderToCreate).then((createdOrder) => {
+            expect(createdOrder.purchaseOrderNumber).to.equal(expectedPurchaseOrderNumber);
             expect(createdOrder.businessId).to.equal(expectedBusinessId);
             expect(createdOrder.totalPrice).to.equal(orderToCreate.totalPrice);
             expect(createdOrder.additionalFields![0].name).to.equal('name');
@@ -452,6 +456,25 @@ describe('ChannelApe Client', () => {
               expect(actualOrders).to.be.an('array');
               expect(actualOrders.length).to.equal(230);
               expect(actualOrders[0].id).to.equal('dda8a05f-d5dd-4535-9261-b55c501085ef');
+            });
+          });
+        });
+      });
+
+      describe('And a valid purchase order number', () => {
+        context('When retrieving orders', () => {
+          it('Then expect 1 matching order to be returned', () => {
+            const expectedBusinessId = '4baafa5b-4fbf-404e-9766-8a02ad45c3a4';
+            const ordersQueryRequestByBusinessId: OrdersQueryRequestByPurchaseOrderNumber = {
+              businessId: expectedBusinessId,
+              purchaseOrderNumber: '0.3354796505578477'
+            };
+            const actualOrdersPromise = channelApeClient.orders().get(ordersQueryRequestByBusinessId);
+            return actualOrdersPromise.then((actualOrders) => {
+              expect(actualOrders).to.be.an('array');
+              expect(actualOrders.length).to.equal(1);
+              expect(actualOrders[0].id).to.equal('36d00c15-a2a8-43d3-8c4c-f62bba7ade53');
+              expect(actualOrders[0].purchaseOrderNumber).to.equal(ordersQueryRequestByBusinessId.purchaseOrderNumber);
             });
           });
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-sdk",
-	"version": "1.19.0",
+	"version": "1.20.0-develop.0",
 	"description": "A client for interacting with ChannelApe's API",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,8 @@ export { default as OrderUpdateRequest } from './orders/model/OrderUpdateRequest
 export { default as OrdersQueryRequestByBusinessId } from './orders/model/OrdersQueryRequestByBusinessId';
 export { default as OrdersQueryRequestByChannel } from './orders/model/OrdersQueryRequestByChannel';
 export { default as OrdersQueryRequestByChannelOrderId } from './orders/model/OrdersQueryRequestByChannelOrderId';
+export { default as OrdersQueryRequestByPurchaseOrderNumber }
+  from './orders/model/OrdersQueryRequestByPurchaseOrderNumber';
 export { default as OrderActivityCreateRequestByChannel }
   from './orders/service/activities/model/OrderActivityCreateRequestByChannel';
 export { default as OrderActivityCreateRequestByOrderId }

--- a/src/orders/model/Order.ts
+++ b/src/orders/model/Order.ts
@@ -12,6 +12,7 @@ export default interface Order {
   channelId: string;
   businessId: string;
   purchasedAt: Date;
+  purchaseOrderNumber?: string;
   canceledAt?: Date;
   canceledReason?: string;
   updatedAt: Date;

--- a/src/orders/model/OrderCreateRequest.ts
+++ b/src/orders/model/OrderCreateRequest.ts
@@ -9,6 +9,7 @@ export default interface OrderCreateRequest {
   channelOrderId: string;
   channelId: string;
   purchasedAt: Date;
+  purchaseOrderNumber?: string;
   canceledAt?: Date;
   canceledReason?: string;
   customer?: Customer;

--- a/src/orders/model/OrdersQueryRequestByPurchaseOrderNumber.ts
+++ b/src/orders/model/OrdersQueryRequestByPurchaseOrderNumber.ts
@@ -1,0 +1,4 @@
+export default interface OrdersRequestByPurchaseOrderNumber {
+  businessId: string;
+  purchaseOrderNumber: string;
+}

--- a/src/orders/service/OrdersCrudService.ts
+++ b/src/orders/service/OrdersCrudService.ts
@@ -16,6 +16,7 @@ import * as Q from 'q';
 import GenericOrdersQueryRequest from './model/GenericOrdersQueryRequest';
 import OrderPatchRequest from '../model/OrderPatchRequest';
 import JsonOrderFormatterService from './JsonOrderFormatterService';
+import OrdersQueryRequestByPurchaseOrderNumber from '../model/OrdersQueryRequestByPurchaseOrderNumber';
 
 const EXPECTED_GET_STATUS = 200;
 const EXPECTED_CREATE_STATUS = 202;
@@ -29,6 +30,7 @@ export default class OrdersCrudService {
   public get(ordersRequestByBusinessId: OrdersQueryRequestByBusinessId): Promise<Order[]>;
   public get(ordersRequestByChannel: OrdersQueryRequestByChannel): Promise<Order[]>;
   public get(ordersRequestByChannelOrderId: OrdersQueryRequestByChannelOrderId): Promise<Order[]>;
+  public get(ordersQueryRequestByPurchaseOrderNumber: OrdersQueryRequestByPurchaseOrderNumber): Promise<Order[]>;
   public get(orderIdOrRequest: string | GenericOrdersQueryRequest): Promise<Order> | Promise<Order[]> {
     if (typeof orderIdOrRequest === 'string') {
       return this.getByOrderId(orderIdOrRequest);
@@ -111,7 +113,8 @@ export default class OrdersCrudService {
   }
 
   private getOrdersByRequest(ordersRequest: OrdersQueryRequestByBusinessId | OrdersQueryRequestByChannel |
-    OrdersQueryRequestByChannelOrderId, orders: Order[], deferred: Q.Deferred<any>, getSinglePage: boolean): void {
+    OrdersQueryRequestByChannelOrderId | OrdersQueryRequestByPurchaseOrderNumber,
+    orders: Order[], deferred: Q.Deferred<any>, getSinglePage: boolean): void {
     const requestUrl = `/${Version.V1}${Resource.ORDERS}`;
     const ordersQueryParams = ordersRequest as any;
     if (ordersQueryParams.startDate != null && typeof ordersQueryParams.startDate !== 'string') {

--- a/src/orders/service/OrdersService.ts
+++ b/src/orders/service/OrdersService.ts
@@ -5,6 +5,8 @@ import OrdersPage from '../model/OrdersPage';
 import OrdersQueryRequestByBusinessId from '../model/OrdersQueryRequestByBusinessId';
 import OrdersQueryRequestByChannel from '../model/OrdersQueryRequestByChannel';
 import OrdersQueryRequestByChannelOrderId from '../model/OrdersQueryRequestByChannelOrderId';
+import OrdersQueryRequestByPurchaseOrderNumber from '../model/OrdersQueryRequestByPurchaseOrderNumber';
+
 import OrderActivitiesService from './activities/OrderActivitiesService';
 import RequestClientWrapper from '../../RequestClientWrapper';
 import GenericOrdersQueryRequest from './model/GenericOrdersQueryRequest';
@@ -28,6 +30,7 @@ export default class OrdersService {
   public get(ordersRequestByBusinessId: OrdersQueryRequestByBusinessId): Promise<Order[]>;
   public get(ordersRequestByChannel: OrdersQueryRequestByChannel): Promise<Order[]>;
   public get(ordersRequestByChannelOrderId: OrdersQueryRequestByChannelOrderId): Promise<Order[]>;
+  public get(ordersRequestByPurchaseOrderNumber: OrdersQueryRequestByPurchaseOrderNumber): Promise<Order[]>;
   public get(orderIdOrRequest: string | GenericOrdersQueryRequest): Promise<Order> | Promise<Order[]> {
     return this.ordersCrudService.get(orderIdOrRequest as any);
   }

--- a/src/orders/service/model/GenericOrdersQueryRequest.ts
+++ b/src/orders/service/model/GenericOrdersQueryRequest.ts
@@ -1,6 +1,10 @@
-import { OrdersQueryRequestByBusinessId, OrdersQueryRequestByChannel, OrdersQueryRequestByChannelOrderId }
+import { OrdersQueryRequestByBusinessId, OrdersQueryRequestByChannel,
+  OrdersQueryRequestByChannelOrderId,
+  OrdersQueryRequestByPurchaseOrderNumber
+}
   from '../../../../src';
 
 type GenericOrdersQueryRequest =
-  OrdersQueryRequestByBusinessId | OrdersQueryRequestByChannel | OrdersQueryRequestByChannelOrderId;
+  OrdersQueryRequestByBusinessId | OrdersQueryRequestByChannel | OrdersQueryRequestByChannelOrderId
+  | OrdersQueryRequestByPurchaseOrderNumber;
 export default GenericOrdersQueryRequest;

--- a/test/orders/resources/singleCanceledOrder.ts
+++ b/test/orders/resources/singleCanceledOrder.ts
@@ -120,6 +120,7 @@ export default {
   channelId: 'c815980f-2591-4be7-958c-0477c4cc6df5',
   channelOrderId: '347354628999',
   createdAt: '2018-05-05T16:39:00.590Z',
+  purchaseOrderNumber: '123456',
   customer: {
     additionalFields: [
       {

--- a/test/orders/resources/singleOrder.ts
+++ b/test/orders/resources/singleOrder.ts
@@ -109,6 +109,7 @@ const singleOrder: Order = {
   channelId: '0d134d16-ad7e-4724-841e-7d46e0f128bd',
   channelOrderId: '314980073478',
   createdAt: new Date('2018-05-03T18:07:58.009Z'),
+  purchaseOrderNumber: '123456',
   customer: {
     additionalFields: [
       {

--- a/test/orders/resources/singleOrderToPatch.ts
+++ b/test/orders/resources/singleOrderToPatch.ts
@@ -121,6 +121,7 @@ const singleOrderToPatch: Partial<Order> = {
   channelId: '0d134d16-ad7e-4724-841e-7d46e0f128bd',
   channelOrderId: '314980073478',
   createdAt: new Date('2018-05-03T18:07:58.009Z'),
+  purchaseOrderNumber: '123456',
   customer: {
     additionalFields: [
       {

--- a/test/orders/resources/singleOrderToUpdate.ts
+++ b/test/orders/resources/singleOrderToUpdate.ts
@@ -121,6 +121,7 @@ const singleOrderToUpdate: Order = {
   channelId: '0d134d16-ad7e-4724-841e-7d46e0f128bd',
   channelOrderId: '314980073478',
   createdAt: new Date('2018-05-03T18:07:58.009Z'),
+  purchaseOrderNumber: '123456',
   customer: {
     additionalFields: [
       {

--- a/test/orders/resources/singleOrderWithOneLineItemAndOneFulfillment.ts
+++ b/test/orders/resources/singleOrderWithOneLineItemAndOneFulfillment.ts
@@ -120,6 +120,7 @@ export default {
   channelId: 'c815980f-2591-4be7-958c-0477c4cc6df5',
   channelOrderId: '347354628999',
   createdAt: '2018-05-05T16:39:00.590Z',
+  purchaseOrderNumber: '123456',
   customer: {
     additionalFields: [
       {


### PR DESCRIPTION
* Adds po number to all order models(Order, OrderCreate, OrderUpdate, OrderPatch)
* Adds new ability to query by businessId and purchase Order number