### PR TITLE
Adds keep alive connections and max sockets

### DIFF
--- a/src/ChannelApeClient.ts
+++ b/src/ChannelApeClient.ts
@@ -15,7 +15,7 @@ import ProductFiltersService from './products/filters/service/ProductFiltersServ
 import UsersService from './users/service/UsersService';
 import InventoriesService from './inventories/service/InventoriesService';
 import LocationsService from './locations/service/LocationsService';
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosPromise } from 'axios';
+import axios from 'axios';
 import * as https from 'https';
 import * as http from 'http';
 

--- a/src/ChannelApeClient.ts
+++ b/src/ChannelApeClient.ts
@@ -15,6 +15,9 @@ import ProductFiltersService from './products/filters/service/ProductFiltersServ
 import UsersService from './users/service/UsersService';
 import InventoriesService from './inventories/service/InventoriesService';
 import LocationsService from './locations/service/LocationsService';
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosPromise } from 'axios';
+import * as https from 'https';
+import * as http from 'http';
 
 const MISSING_SESSION_ID_ERROR_MESSAGE = 'sessionId is required.';
 const MINIMUM_REQUEST_RETRY_RANDOM_DELAY_TOO_SMALL_ERROR_MESSAGE =
@@ -78,6 +81,14 @@ export default class ChannelApeClient {
     this.maximumConcurrentConnections =
       clientConfiguration.maximumConcurrentConnections ?
       clientConfiguration.maximumConcurrentConnections : 5;
+    const httpAgent = new http.Agent(
+      { keepAlive: true, maxSockets: this.maximumConcurrentConnections });
+    const httpsAgent = new https.Agent(
+      { keepAlive: true, maxSockets: this.maximumConcurrentConnections });
+    const axiosInstance = axios.create({
+      httpAgent,
+      httpsAgent
+    });
 
     this.requestClientWrapper = new RequestClientWrapper({
       timeout: this.timeout,
@@ -88,7 +99,7 @@ export default class ChannelApeClient {
       minimumRequestRetryRandomDelay: this.minimumRequestRetryRandomDelay,
       maximumRequestRetryRandomDelay: this.maximumRequestRetryRandomDelay,
       maximumConcurrentConnections: this.maximumConcurrentConnections
-    });
+    }, axiosInstance);
     this.actionsService = new ActionsService(this.requestClientWrapper);
     this.channelsService = new ChannelsService(this.requestClientWrapper);
     this.suppliersService = new SuppliersService(this.requestClientWrapper);

--- a/src/RequestClientWrapper.ts
+++ b/src/RequestClientWrapper.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosPromise } from 'axios';
+import { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosPromise } from 'axios';
 import RequestLogger from './utils/RequestLogger';
 import ChannelApeError from './model/ChannelApeError';
 import HttpRequestMethod from './model/HttpRequestMethod';

--- a/test/RequestClientWrapper.spec.ts
+++ b/test/RequestClientWrapper.spec.ts
@@ -1,7 +1,7 @@
 // tslint:disable:no-trailing-whitespace
 import * as sinon from 'sinon';
 import { expect } from 'chai';
-import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import axiosMockAdapter from 'axios-mock-adapter';
 import { Logger } from 'channelape-logger';
 

--- a/test/actions/service/ActionsService.spec.ts
+++ b/test/actions/service/ActionsService.spec.ts
@@ -10,6 +10,7 @@ import Environment from '../../../src/model/Environment';
 import ChannelApeApiErrorResponse from '../../../src/model/ChannelApeApiErrorResponse';
 import RequestClientWrapper from '../../../src/RequestClientWrapper';
 import ChannelApeError from '../../../src/model/ChannelApeError';
+import axios from 'axios';
 
 import actionsFirstPageResponse from '../resources/actionsFirstPageResponse';
 import actionsFinalPageResponse from '../resources/actionsFinalPageResponse';
@@ -27,7 +28,7 @@ describe('Actions Service', () => {
         minimumRequestRetryRandomDelay: 50,
         maximumRequestRetryRandomDelay: 50,
         maximumConcurrentConnections: 5
-      });
+      }, axios);
 
     let sandbox: sinon.SinonSandbox;
 

--- a/test/analytics/service/AnalyticsService.spec.ts
+++ b/test/analytics/service/AnalyticsService.spec.ts
@@ -11,6 +11,7 @@ import Embed from './../../../src/analytics/model/Embed';
 import AnalyticsService from './../../../src/analytics/service/AnalyticsService';
 import Report from './../../../src/analytics/model/Report';
 import { Token } from './../../../src/analytics/model/Token';
+import axios from 'axios';
 
 describe('Analytics Service', () => {
 
@@ -25,7 +26,7 @@ describe('Analytics Service', () => {
         minimumRequestRetryRandomDelay: 50,
         maximumRequestRetryRandomDelay: 50,
         maximumConcurrentConnections: 5
-      });
+      }, axios);
 
     let sandbox: sinon.SinonSandbox;
 

--- a/test/businesses/service/BusinessesService.spec.ts
+++ b/test/businesses/service/BusinessesService.spec.ts
@@ -28,7 +28,7 @@ describe('Businesses Service', () => {
         minimumRequestRetryRandomDelay: 50,
         maximumRequestRetryRandomDelay: 50,
         maximumConcurrentConnections: 5
-      });
+      }, axios);
     const businessesService: BusinessesService = new BusinessesService(client);
 
     let sandbox: sinon.SinonSandbox;

--- a/test/channels/service/ChannelsService.spec.ts
+++ b/test/channels/service/ChannelsService.spec.ts
@@ -9,7 +9,7 @@ import ChannelApeApiErrorResponse from '../../../src/model/ChannelApeApiErrorRes
 import Channel from '../../../src/channels/model/Channel';
 import RequestClientWrapper from '../../../src/RequestClientWrapper';
 import { ChannelApeError } from '../../../src/index';
-
+import axios from 'axios';
 describe('Channels Service', () => {
 
   describe('Given some rest client', () => {
@@ -23,7 +23,7 @@ describe('Channels Service', () => {
         minimumRequestRetryRandomDelay: 50,
         maximumRequestRetryRandomDelay: 50,
         maximumConcurrentConnections: 5
-      });
+      }, axios);
 
     let sandbox: sinon.SinonSandbox;
 

--- a/test/inventories/quantities/Service/InventoryItemQuantitiesService.spec.ts
+++ b/test/inventories/quantities/Service/InventoryItemQuantitiesService.spec.ts
@@ -10,6 +10,7 @@ import AdjustmentRequest from '../../../../src/inventories/quantities/model/Adju
 import InventoryItemQuantitiesService from '../../../../src/inventories/quantities/InventoryItemQuantitiesService';
 import SubResource from '../../../../src/model/SubResource';
 import { fail } from 'assert';
+import axios from 'axios';
 
 describe('Inventory Quantities Service', () => {
 
@@ -24,7 +25,7 @@ describe('Inventory Quantities Service', () => {
         minimumRequestRetryRandomDelay: 50,
         maximumRequestRetryRandomDelay: 50,
         maximumConcurrentConnections: 5
-      });
+      }, axios);
 
     let sandbox: sinon.SinonSandbox;
 

--- a/test/inventories/service/InventoriesService.spec.ts
+++ b/test/inventories/service/InventoriesService.spec.ts
@@ -10,7 +10,7 @@ import ChannelApeApiErrorResponse from '../../../src/model/ChannelApeApiErrorRes
 import { fail } from 'assert';
 import { InventoryItemCreateRequest } from './../../../src/inventories/model/InventoryItemCreateRequest';
 import { InventoryItemUpdateRequest } from './../../../src/inventories/model/InventoryItemUpdateRequest';
-
+import axios from 'axios';
 describe('Inventories Service', () => {
 
   describe('Given some rest client', () => {
@@ -24,7 +24,7 @@ describe('Inventories Service', () => {
         minimumRequestRetryRandomDelay: 50,
         maximumRequestRetryRandomDelay: 50,
         maximumConcurrentConnections: 5
-      });
+      }, axios);
 
     let sandbox: sinon.SinonSandbox;
 

--- a/test/locations/service/LocationsService.spec.ts
+++ b/test/locations/service/LocationsService.spec.ts
@@ -10,7 +10,7 @@ import { fail } from 'assert';
 import LocationsService from './../../../src/locations/service/LocationsService';
 import LocationCreateRequest from './../../../src/locations/model/LocationCreateRequest';
 import LocationUpdateRequest from './../../../src/locations/model/LocationUpdateRequest';
-
+import axios from 'axios';
 describe('Locations Service', () => {
 
   describe('Given some rest client', () => {
@@ -24,7 +24,7 @@ describe('Locations Service', () => {
         minimumRequestRetryRandomDelay: 50,
         maximumRequestRetryRandomDelay: 50,
         maximumConcurrentConnections: 5
-      });
+      }, axios);
 
     let sandbox: sinon.SinonSandbox;
 

--- a/test/orders/service/OrdersService.spec.ts
+++ b/test/orders/service/OrdersService.spec.ts
@@ -38,7 +38,7 @@ const clientWrapper: RequestClientWrapper = new RequestClientWrapper({
   minimumRequestRetryRandomDelay: 50,
   maximumRequestRetryRandomDelay: 50,
   maximumConcurrentConnections: 5
-});
+}, axios);
 const ordersService: OrdersService = new OrdersService(clientWrapper);
 
 describe('OrdersService', () => {
@@ -531,7 +531,7 @@ Code: 12 Message: Invalid authorization token. Please check the server logs and 
         minimumRequestRetryRandomDelay: 50,
         maximumRequestRetryRandomDelay: 50,
         maximumConcurrentConnections: 5
-      });
+      }, axios);
       const ordersService: OrdersService = new OrdersService(client);
       const orderId = 'not-a-real-order-id';
       return ordersService.get(orderId).then((actualOrder) => {
@@ -553,7 +553,7 @@ Code: 12 Message: Invalid authorization token. Please check the server logs and 
         minimumRequestRetryRandomDelay: 50,
         maximumRequestRetryRandomDelay: 50,
         maximumConcurrentConnections: 5
-      });
+      }, axios);
       const expectedErrorMessage =
 `get /v1/orders
   Status: 401

--- a/test/orders/service/activities/OrderActivitiesService.spec.ts
+++ b/test/orders/service/activities/OrderActivitiesService.spec.ts
@@ -26,7 +26,7 @@ const clientWrapper: RequestClientWrapper = new RequestClientWrapper({
   minimumRequestRetryRandomDelay: 50,
   maximumRequestRetryRandomDelay: 50,
   maximumConcurrentConnections: 5
-});
+}, axios);
 
 const ordersService: OrdersService = new OrdersService(clientWrapper);
 
@@ -220,7 +220,7 @@ Code: 167 Message: Channel order ID cannot be blank.`;
         minimumRequestRetryRandomDelay: 50,
         maximumRequestRetryRandomDelay: 50,
         maximumConcurrentConnections: 5
-      });
+      }, axios);
       const ordersService: OrdersService = new OrdersService(client);
       return ordersService.activities().create({} as any).then((actualOrderActivity) => {
         throw new Error('Test failed!');

--- a/test/products/filters/ProductFiltersService.spec.ts
+++ b/test/products/filters/ProductFiltersService.spec.ts
@@ -21,7 +21,7 @@ const clientWrapper: RequestClientWrapper = new RequestClientWrapper({
   minimumRequestRetryRandomDelay: 50,
   maximumRequestRetryRandomDelay: 50,
   maximumConcurrentConnections: 5
-});
+}, axios);
 const productFiltersService: ProductFiltersService = new ProductFiltersService(clientWrapper);
 
 describe('ProductFiltersService', () => {

--- a/test/sessions/service/SessionsService.spec.ts
+++ b/test/sessions/service/SessionsService.spec.ts
@@ -24,7 +24,7 @@ describe('Sessions Service', () => {
         minimumRequestRetryRandomDelay: 50,
         maximumRequestRetryRandomDelay: 50,
         maximumConcurrentConnections: 5
-      });
+      }, axios);
     const sessionId = 'b40da0b8-a770-4de7-a496-361254bd7d6c';
     const userId = 'f6ed6f7a-47bf-4dd3-baed-71a8a9684e80';
     const sessionsService = new SessionsService(client);

--- a/test/subscriptions/service/SubscriptionService.spec.ts
+++ b/test/subscriptions/service/SubscriptionService.spec.ts
@@ -24,7 +24,7 @@ describe('Subscriptions Service', () => {
         minimumRequestRetryRandomDelay: 50,
         maximumRequestRetryRandomDelay: 50,
         maximumConcurrentConnections: 5
-      });
+      }, axios);
     const active = true;
     const businessId = 'f6ed6f7a-47bf-4dd3-baed-71a8a9684e80';
     const createdAt = '2018-02-22T16:03:42.662Z';

--- a/test/suppliers/service/SuppliersService.spec.ts
+++ b/test/suppliers/service/SuppliersService.spec.ts
@@ -9,6 +9,7 @@ import ChannelApeApiErrorResponse from '../../../src/model/ChannelApeApiErrorRes
 import Supplier from '../../../src/suppliers/model/Supplier';
 import RequestClientWrapper from '../../../src/RequestClientWrapper';
 import { ChannelApeError } from '../../../src/index';
+import axios from 'axios';
 
 describe('Suppliers Service', () => {
 
@@ -23,7 +24,7 @@ describe('Suppliers Service', () => {
         minimumRequestRetryRandomDelay: 50,
         maximumRequestRetryRandomDelay: 50,
         maximumConcurrentConnections: 5
-      });
+      }, axios);
 
     let sandbox: sinon.SinonSandbox;
 

--- a/test/users/service/UsersService.spec.ts
+++ b/test/users/service/UsersService.spec.ts
@@ -6,6 +6,7 @@ import Resource from '../../../src/model/Resource';
 import Environment from '../../../src/model/Environment';
 import RequestClientWrapper from '../../../src/RequestClientWrapper';
 import UsersService from './../../../src/users/service/UsersService';
+import axios from 'axios';
 
 describe('Users Service', () => {
 
@@ -20,7 +21,7 @@ describe('Users Service', () => {
         minimumRequestRetryRandomDelay: 50,
         maximumRequestRetryRandomDelay: 50,
         maximumConcurrentConnections: 5
-      });
+      }, axios);
 
     let sandbox: sinon.SinonSandbox;
 

--- a/test/variants/service/VariantService.spec.ts
+++ b/test/variants/service/VariantService.spec.ts
@@ -68,7 +68,7 @@ const clientWrapper: RequestClientWrapper = new RequestClientWrapper({
   minimumRequestRetryRandomDelay: 50,
   maximumRequestRetryRandomDelay: 50,
   maximumConcurrentConnections: 5
-});
+}, axios);
 const variantsService: VariantsService = new VariantsService(clientWrapper);
 
 describe('VariantsService', () => {


### PR DESCRIPTION
This leverages the built in configs that axios exposes in their configs instead of manually trying to manage them. The only difference is  passing in the http agents to axios client. I will also verify that this works with non-node applications.

Also added the keep alive so that connections are pooled. There are other configs we can leverage if necessary, but a local test proved that this worked with internal services