### PR TITLE
Adds restock type to refund line items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "7.5.0"
+				"@babel/highlight": "^7.0.0"
 			}
 		},
 		"@babel/highlight": {
@@ -19,9 +19,9 @@
 			"integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.2",
-				"esutils": "2.0.3",
-				"js-tokens": "4.0.0"
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
 			}
 		},
 		"@fimbul/bifrost": {
@@ -30,10 +30,10 @@
 			"integrity": "sha512-ou8VU+nTmOW1jeg+FT+sn+an/M0Xb9G16RucrfhjXGWv1Q97kCoM5CG9Qj7GYOSdu7km72k7nY83Eyr53Bkakg==",
 			"dev": true,
 			"requires": {
-				"@fimbul/ymir": "0.21.0",
-				"get-caller-file": "2.0.5",
-				"tslib": "1.10.0",
-				"tsutils": "3.17.1"
+				"@fimbul/ymir": "^0.21.0",
+				"get-caller-file": "^2.0.0",
+				"tslib": "^1.8.1",
+				"tsutils": "^3.5.0"
 			},
 			"dependencies": {
 				"get-caller-file": {
@@ -48,7 +48,7 @@
 					"integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
 					"dev": true,
 					"requires": {
-						"tslib": "1.10.0"
+						"tslib": "^1.8.1"
 					}
 				}
 			}
@@ -59,9 +59,9 @@
 			"integrity": "sha512-T/y7WqPsm4n3zhT08EpB5sfdm2Kvw3gurAxr2Lr5dQeLi8ZsMlNT/Jby+ZmuuAAd1PnXYzKp+2SXgIkQIIMCUg==",
 			"dev": true,
 			"requires": {
-				"inversify": "5.0.1",
-				"reflect-metadata": "0.1.13",
-				"tslib": "1.10.0"
+				"inversify": "^5.0.0",
+				"reflect-metadata": "^0.1.12",
+				"tslib": "^1.8.1"
 			}
 		},
 		"@sinonjs/commons": {
@@ -88,9 +88,9 @@
 			"integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/commons": "1.7.0",
-				"array-from": "2.1.1",
-				"lodash": "4.17.15"
+				"@sinonjs/commons": "^1.3.0",
+				"array-from": "^2.1.1",
+				"lodash": "^4.17.15"
 			}
 		},
 		"@sinonjs/text-encoding": {
@@ -111,7 +111,7 @@
 			"integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
 			"dev": true,
 			"requires": {
-				"axios": "0.18.1"
+				"axios": "*"
 			}
 		},
 		"@types/chai": {
@@ -162,7 +162,7 @@
 			"integrity": "sha512-cCdlC/1kGEZdEglzOieLDYBxHsvEOIg7kp/2FYyVR9Pxakq+Qf/inL3RKQ+PA8gOlI/NnL+fXmQH12nwcGzsHw==",
 			"dev": true,
 			"requires": {
-				"@types/node": "10.17.13"
+				"@types/node": "*"
 			}
 		},
 		"ansi-regex": {
@@ -177,7 +177,7 @@
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
 			"requires": {
-				"color-convert": "1.9.3"
+				"color-convert": "^1.9.0"
 			}
 		},
 		"app-root-path": {
@@ -192,7 +192,7 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"array-from": {
@@ -219,7 +219,7 @@
 			"integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
 			"requires": {
 				"follow-redirects": "1.5.10",
-				"is-buffer": "2.0.4"
+				"is-buffer": "^2.0.2"
 			}
 		},
 		"axios-mock-adapter": {
@@ -228,7 +228,7 @@
 			"integrity": "sha512-q3efmwJUOO4g+wsLNSk9Ps1UlJoF3fQ3FSEe4uEEhkRtu7SoiAVPj8R3Hc/WP55MBTVFzaDP9QkdJhdVhP8A1Q==",
 			"dev": true,
 			"requires": {
-				"deep-equal": "1.1.1"
+				"deep-equal": "^1.0.1"
 			}
 		},
 		"balanced-match": {
@@ -243,7 +243,7 @@
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -277,12 +277,12 @@
 			"integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
 			"dev": true,
 			"requires": {
-				"assertion-error": "1.1.0",
-				"check-error": "1.0.2",
-				"deep-eql": "3.0.1",
-				"get-func-name": "2.0.0",
-				"pathval": "1.1.0",
-				"type-detect": "4.0.8"
+				"assertion-error": "^1.1.0",
+				"check-error": "^1.0.2",
+				"deep-eql": "^3.0.1",
+				"get-func-name": "^2.0.0",
+				"pathval": "^1.1.0",
+				"type-detect": "^4.0.5"
 			}
 		},
 		"chalk": {
@@ -291,9 +291,9 @@
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.5.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -302,7 +302,7 @@
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -324,9 +324,9 @@
 			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 			"dev": true,
 			"requires": {
-				"string-width": "2.1.1",
-				"strip-ansi": "4.0.0",
-				"wrap-ansi": "2.1.0"
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
 			}
 		},
 		"code-point-at": {
@@ -368,15 +368,15 @@
 			"integrity": "sha512-/+ugz+gwFSEfTGUxn0KHkY+19XPRTXR8+7oUK/HxgiN1n7FjeJmkrbSiXAJfyQ0zORgJYPaenmymwon51YXH9Q==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.2",
+				"chalk": "^2.4.1",
 				"commander": "2.6.0",
-				"date-fns": "1.30.1",
-				"lodash": "4.17.15",
-				"read-pkg": "3.0.0",
+				"date-fns": "^1.23.0",
+				"lodash": "^4.5.1",
+				"read-pkg": "^3.0.0",
 				"rx": "2.3.24",
-				"spawn-command": "0.0.2-1",
-				"supports-color": "3.2.3",
-				"tree-kill": "1.2.2"
+				"spawn-command": "^0.0.2-1",
+				"supports-color": "^3.2.3",
+				"tree-kill": "^1.1.0"
 			}
 		},
 		"cross-spawn": {
@@ -385,11 +385,11 @@
 			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 			"dev": true,
 			"requires": {
-				"nice-try": "1.0.5",
-				"path-key": "2.0.1",
-				"semver": "5.7.1",
-				"shebang-command": "1.2.0",
-				"which": "1.3.1"
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
 			}
 		},
 		"date-fns": {
@@ -418,7 +418,7 @@
 			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
 			"dev": true,
 			"requires": {
-				"type-detect": "4.0.8"
+				"type-detect": "^4.0.0"
 			}
 		},
 		"deep-equal": {
@@ -427,12 +427,12 @@
 			"integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
 			"dev": true,
 			"requires": {
-				"is-arguments": "1.0.4",
-				"is-date-object": "1.0.2",
-				"is-regex": "1.0.5",
-				"object-is": "1.0.2",
-				"object-keys": "1.1.1",
-				"regexp.prototype.flags": "1.3.0"
+				"is-arguments": "^1.0.4",
+				"is-date-object": "^1.0.1",
+				"is-regex": "^1.0.4",
+				"object-is": "^1.0.1",
+				"object-keys": "^1.1.1",
+				"regexp.prototype.flags": "^1.2.0"
 			}
 		},
 		"define-properties": {
@@ -441,7 +441,7 @@
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
 			"dev": true,
 			"requires": {
-				"object-keys": "1.1.1"
+				"object-keys": "^1.0.12"
 			}
 		},
 		"diff": {
@@ -456,7 +456,7 @@
 			"integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
 			"dev": true,
 			"requires": {
-				"esutils": "1.1.6",
+				"esutils": "^1.1.6",
 				"isarray": "0.0.1"
 			},
 			"dependencies": {
@@ -474,7 +474,7 @@
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0"
+				"once": "^1.4.0"
 			}
 		},
 		"error-ex": {
@@ -483,7 +483,7 @@
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -492,17 +492,17 @@
 			"integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "1.2.1",
-				"function-bind": "1.1.1",
-				"has": "1.0.3",
-				"has-symbols": "1.0.1",
-				"is-callable": "1.1.5",
-				"is-regex": "1.0.5",
-				"object-inspect": "1.7.0",
-				"object-keys": "1.1.1",
-				"object.assign": "4.1.0",
-				"string.prototype.trimleft": "2.1.1",
-				"string.prototype.trimright": "2.1.1"
+				"es-to-primitive": "^1.2.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1",
+				"is-callable": "^1.1.5",
+				"is-regex": "^1.0.5",
+				"object-inspect": "^1.7.0",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.0",
+				"string.prototype.trimleft": "^2.1.1",
+				"string.prototype.trimright": "^2.1.1"
 			}
 		},
 		"es-to-primitive": {
@@ -511,9 +511,9 @@
 			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
 			"dev": true,
 			"requires": {
-				"is-callable": "1.1.5",
-				"is-date-object": "1.0.2",
-				"is-symbol": "1.0.3"
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
 			}
 		},
 		"escape-string-regexp": {
@@ -540,13 +540,13 @@
 			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "6.0.5",
-				"get-stream": "4.1.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
+				"cross-spawn": "^6.0.0",
+				"get-stream": "^4.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			}
 		},
 		"faker": {
@@ -561,7 +561,7 @@
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"dev": true,
 			"requires": {
-				"locate-path": "2.0.0"
+				"locate-path": "^2.0.0"
 			}
 		},
 		"follow-redirects": {
@@ -569,7 +569,7 @@
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
 			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
 			"requires": {
-				"debug": "3.1.0"
+				"debug": "=3.1.0"
 			}
 		},
 		"fs.realpath": {
@@ -602,7 +602,7 @@
 			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
 			"dev": true,
 			"requires": {
-				"pump": "3.0.0"
+				"pump": "^3.0.0"
 			}
 		},
 		"glob": {
@@ -611,12 +611,12 @@
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.4",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -637,7 +637,7 @@
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"dev": true,
 			"requires": {
-				"function-bind": "1.1.1"
+				"function-bind": "^1.1.1"
 			}
 		},
 		"has-flag": {
@@ -670,8 +670,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -733,7 +733,7 @@
 			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
 			"dev": true,
 			"requires": {
-				"has": "1.0.3"
+				"has": "^1.0.3"
 			}
 		},
 		"is-stream": {
@@ -748,7 +748,7 @@
 			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
 			"dev": true,
 			"requires": {
-				"has-symbols": "1.0.1"
+				"has-symbols": "^1.0.1"
 			}
 		},
 		"isarray": {
@@ -775,8 +775,8 @@
 			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
 			"dev": true,
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.1"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"json-parse-better-errors": {
@@ -797,7 +797,7 @@
 			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
 			"dev": true,
 			"requires": {
-				"invert-kv": "2.0.0"
+				"invert-kv": "^2.0.0"
 			}
 		},
 		"load-json-file": {
@@ -806,10 +806,10 @@
 			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.2.3",
-				"parse-json": "4.0.0",
-				"pify": "3.0.0",
-				"strip-bom": "3.0.0"
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"locate-path": {
@@ -818,8 +818,8 @@
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
@@ -852,7 +852,7 @@
 			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
 			"dev": true,
 			"requires": {
-				"p-defer": "1.0.0"
+				"p-defer": "^1.0.0"
 			}
 		},
 		"mem": {
@@ -861,9 +861,9 @@
 			"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 			"dev": true,
 			"requires": {
-				"map-age-cleaner": "0.1.3",
-				"mimic-fn": "2.1.0",
-				"p-is-promise": "2.1.0"
+				"map-age-cleaner": "^0.1.1",
+				"mimic-fn": "^2.0.0",
+				"p-is-promise": "^2.0.0"
 			}
 		},
 		"mimic-fn": {
@@ -878,7 +878,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -927,7 +927,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -938,10 +938,10 @@
 			"integrity": "sha512-Ge6pCQkZumkkhxVNdAf3JxunskShgaynCb30HYD7TT1Yhog/7NW2+6w5RcRHI+nuQrCMTX6z1+qf2pD8qwCoQA==",
 			"dev": true,
 			"requires": {
-				"@types/mocha": "5.2.7",
-				"chalk": "2.4.2",
-				"cross-spawn": "6.0.5",
-				"yargs": "11.1.1"
+				"@types/mocha": "^5.2.0",
+				"chalk": "^2.4.1",
+				"cross-spawn": "^6.0.5",
+				"yargs": "^11.0.0"
 			}
 		},
 		"ms": {
@@ -961,11 +961,11 @@
 			"integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "3.2.2",
-				"@sinonjs/text-encoding": "0.7.1",
-				"just-extend": "4.0.2",
-				"lolex": "5.1.2",
-				"path-to-regexp": "1.8.0"
+				"@sinonjs/formatio": "^3.2.1",
+				"@sinonjs/text-encoding": "^0.7.1",
+				"just-extend": "^4.0.2",
+				"lolex": "^5.0.1",
+				"path-to-regexp": "^1.7.0"
 			},
 			"dependencies": {
 				"@sinonjs/formatio": {
@@ -974,8 +974,8 @@
 					"integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
 					"dev": true,
 					"requires": {
-						"@sinonjs/commons": "1.7.0",
-						"@sinonjs/samsam": "3.3.3"
+						"@sinonjs/commons": "^1",
+						"@sinonjs/samsam": "^3.1.0"
 					}
 				},
 				"lolex": {
@@ -984,7 +984,7 @@
 					"integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
 					"dev": true,
 					"requires": {
-						"@sinonjs/commons": "1.7.0"
+						"@sinonjs/commons": "^1.7.0"
 					}
 				}
 			}
@@ -995,10 +995,10 @@
 			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "2.8.5",
-				"resolve": "1.14.1",
-				"semver": "5.7.1",
-				"validate-npm-package-license": "3.0.4"
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"npm-run-path": {
@@ -1007,7 +1007,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "2.0.1"
+				"path-key": "^2.0.0"
 			}
 		},
 		"number-is-nan": {
@@ -1022,43 +1022,44 @@
 			"integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
 			"dev": true,
 			"requires": {
-				"archy": "1.0.0",
-				"arrify": "1.0.1",
-				"caching-transform": "1.0.1",
-				"convert-source-map": "1.5.1",
-				"debug-log": "1.0.1",
-				"default-require-extensions": "1.0.0",
-				"find-cache-dir": "0.1.1",
-				"find-up": "2.1.0",
-				"foreground-child": "1.5.6",
-				"glob": "7.1.2",
-				"istanbul-lib-coverage": "1.2.0",
-				"istanbul-lib-hook": "1.1.0",
-				"istanbul-lib-instrument": "1.10.1",
-				"istanbul-lib-report": "1.1.3",
-				"istanbul-lib-source-maps": "1.2.3",
-				"istanbul-reports": "1.4.0",
-				"md5-hex": "1.3.0",
-				"merge-source-map": "1.1.0",
-				"micromatch": "3.1.10",
-				"mkdirp": "0.5.1",
-				"resolve-from": "2.0.0",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"spawn-wrap": "1.4.2",
-				"test-exclude": "4.2.1",
+				"archy": "^1.0.0",
+				"arrify": "^1.0.1",
+				"caching-transform": "^1.0.0",
+				"convert-source-map": "^1.5.1",
+				"debug-log": "^1.0.1",
+				"default-require-extensions": "^1.0.0",
+				"find-cache-dir": "^0.1.1",
+				"find-up": "^2.1.0",
+				"foreground-child": "^1.5.3",
+				"glob": "^7.0.6",
+				"istanbul-lib-coverage": "^1.1.2",
+				"istanbul-lib-hook": "^1.1.0",
+				"istanbul-lib-instrument": "^1.10.0",
+				"istanbul-lib-report": "^1.1.3",
+				"istanbul-lib-source-maps": "^1.2.3",
+				"istanbul-reports": "^1.4.0",
+				"md5-hex": "^1.2.0",
+				"merge-source-map": "^1.1.0",
+				"micromatch": "^3.1.10",
+				"mkdirp": "^0.5.0",
+				"resolve-from": "^2.0.0",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.1",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^4.2.0",
 				"yargs": "11.1.0",
-				"yargs-parser": "8.1.0"
+				"yargs-parser": "^8.0.0"
 			},
 			"dependencies": {
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
-						"kind-of": "3.2.2",
-						"longest": "1.0.1",
-						"repeat-string": "1.6.1"
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
 					}
 				},
 				"amdefine": {
@@ -1081,7 +1082,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"default-require-extensions": "1.0.0"
+						"default-require-extensions": "^1.0.0"
 					}
 				},
 				"archy": {
@@ -1134,9 +1135,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"esutils": "2.0.2",
-						"js-tokens": "3.0.2"
+						"chalk": "^1.1.3",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.2"
 					}
 				},
 				"babel-generator": {
@@ -1144,14 +1145,14 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"detect-indent": "4.0.0",
-						"jsesc": "1.3.0",
-						"lodash": "4.17.10",
-						"source-map": "0.5.7",
-						"trim-right": "1.0.1"
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"detect-indent": "^4.0.0",
+						"jsesc": "^1.3.0",
+						"lodash": "^4.17.4",
+						"source-map": "^0.5.7",
+						"trim-right": "^1.0.1"
 					}
 				},
 				"babel-messages": {
@@ -1159,7 +1160,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-runtime": "6.26.0"
+						"babel-runtime": "^6.22.0"
 					}
 				},
 				"babel-runtime": {
@@ -1167,8 +1168,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"core-js": "2.5.6",
-						"regenerator-runtime": "0.11.1"
+						"core-js": "^2.4.0",
+						"regenerator-runtime": "^0.11.0"
 					}
 				},
 				"babel-template": {
@@ -1176,11 +1177,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-runtime": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"lodash": "4.17.10"
+						"babel-runtime": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"lodash": "^4.17.4"
 					}
 				},
 				"babel-traverse": {
@@ -1188,15 +1189,15 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"debug": "2.6.9",
-						"globals": "9.18.0",
-						"invariant": "2.2.4",
-						"lodash": "4.17.10"
+						"babel-code-frame": "^6.26.0",
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"debug": "^2.6.8",
+						"globals": "^9.18.0",
+						"invariant": "^2.2.2",
+						"lodash": "^4.17.4"
 					}
 				},
 				"babel-types": {
@@ -1204,10 +1205,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-runtime": "6.26.0",
-						"esutils": "2.0.2",
-						"lodash": "4.17.10",
-						"to-fast-properties": "1.0.3"
+						"babel-runtime": "^6.26.0",
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.4",
+						"to-fast-properties": "^1.0.3"
 					}
 				},
 				"babylon": {
@@ -1225,13 +1226,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cache-base": "1.0.1",
-						"class-utils": "0.3.6",
-						"component-emitter": "1.2.1",
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"mixin-deep": "1.3.1",
-						"pascalcase": "0.1.1"
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1239,7 +1240,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -1247,7 +1248,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
@@ -1255,7 +1256,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
@@ -1263,9 +1264,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -1285,7 +1286,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -1294,16 +1295,16 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -1311,7 +1312,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1326,15 +1327,15 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"collection-visit": "1.0.0",
-						"component-emitter": "1.2.1",
-						"get-value": "2.0.6",
-						"has-value": "1.0.0",
-						"isobject": "3.0.1",
-						"set-value": "2.0.0",
-						"to-object-path": "0.3.0",
-						"union-value": "1.0.0",
-						"unset-value": "1.0.0"
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1349,9 +1350,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"md5-hex": "1.3.0",
-						"mkdirp": "0.5.1",
-						"write-file-atomic": "1.3.4"
+						"md5-hex": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"write-file-atomic": "^1.1.4"
 					}
 				},
 				"camelcase": {
@@ -1366,8 +1367,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4",
-						"lazy-cache": "1.0.4"
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
 					}
 				},
 				"chalk": {
@@ -1375,11 +1376,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"class-utils": {
@@ -1387,10 +1388,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arr-union": "3.1.0",
-						"define-property": "0.2.5",
-						"isobject": "3.0.1",
-						"static-extend": "0.1.2"
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1398,7 +1399,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"isobject": {
@@ -1414,8 +1415,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
 						"wordwrap": "0.0.2"
 					},
 					"dependencies": {
@@ -1437,8 +1438,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"map-visit": "1.0.0",
-						"object-visit": "1.0.1"
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
 					}
 				},
 				"commondir": {
@@ -1476,8 +1477,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"lru-cache": "4.1.3",
-						"which": "1.3.0"
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -1508,7 +1509,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"strip-bom": "2.0.0"
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"define-property": {
@@ -1516,8 +1517,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2",
-						"isobject": "3.0.1"
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"is-accessor-descriptor": {
@@ -1525,7 +1526,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
@@ -1533,7 +1534,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
@@ -1541,9 +1542,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -1563,7 +1564,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"repeating": "2.0.1"
+						"repeating": "^2.0.0"
 					}
 				},
 				"error-ex": {
@@ -1571,7 +1572,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-arrayish": "0.2.1"
+						"is-arrayish": "^0.2.1"
 					}
 				},
 				"escape-string-regexp": {
@@ -1589,13 +1590,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					},
 					"dependencies": {
 						"cross-spawn": {
@@ -1603,9 +1604,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"lru-cache": "4.1.3",
-								"shebang-command": "1.2.0",
-								"which": "1.3.0"
+								"lru-cache": "^4.0.1",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
 							}
 						}
 					}
@@ -1615,13 +1616,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1629,7 +1630,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -1637,7 +1638,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1647,8 +1648,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"assign-symbols": "1.0.0",
-						"is-extendable": "1.0.1"
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
@@ -1656,7 +1657,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -1666,14 +1667,14 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1681,7 +1682,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -1689,7 +1690,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -1697,7 +1698,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
@@ -1705,7 +1706,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
@@ -1713,9 +1714,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"kind-of": {
@@ -1730,10 +1731,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -1741,7 +1742,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1751,9 +1752,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"commondir": "1.0.1",
-						"mkdirp": "0.5.1",
-						"pkg-dir": "1.0.0"
+						"commondir": "^1.0.1",
+						"mkdirp": "^0.5.1",
+						"pkg-dir": "^1.0.0"
 					}
 				},
 				"find-up": {
@@ -1761,7 +1762,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"for-in": {
@@ -1774,8 +1775,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cross-spawn": "4.0.2",
-						"signal-exit": "3.0.2"
+						"cross-spawn": "^4",
+						"signal-exit": "^3.0.0"
 					}
 				},
 				"fragment-cache": {
@@ -1783,7 +1784,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"map-cache": "0.2.2"
+						"map-cache": "^0.2.2"
 					}
 				},
 				"fs.realpath": {
@@ -1811,12 +1812,12 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"globals": {
@@ -1834,10 +1835,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"async": "1.5.2",
-						"optimist": "0.6.1",
-						"source-map": "0.4.4",
-						"uglify-js": "2.8.29"
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
 					},
 					"dependencies": {
 						"source-map": {
@@ -1845,7 +1846,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"amdefine": "1.0.1"
+								"amdefine": ">=0.0.4"
 							}
 						}
 					}
@@ -1855,7 +1856,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -1868,9 +1869,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "1.0.0",
-						"isobject": "3.0.1"
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -1885,8 +1886,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-number": "3.0.0",
-						"kind-of": "4.0.0"
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
@@ -1894,7 +1895,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -1902,7 +1903,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -1912,7 +1913,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -1932,8 +1933,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -1946,7 +1947,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"loose-envify": "1.3.1"
+						"loose-envify": "^1.0.0"
 					}
 				},
 				"invert-kv": {
@@ -1959,7 +1960,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-arrayish": {
@@ -1977,7 +1978,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"builtin-modules": "1.1.1"
+						"builtin-modules": "^1.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -1985,7 +1986,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -1993,9 +1994,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2015,7 +2016,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -2028,7 +2029,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-odd": {
@@ -2036,7 +2037,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-number": "4.0.0"
+						"is-number": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
@@ -2051,7 +2052,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -2101,7 +2102,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"append-transform": "0.4.0"
+						"append-transform": "^0.4.0"
 					}
 				},
 				"istanbul-lib-instrument": {
@@ -2109,13 +2110,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-generator": "6.26.1",
-						"babel-template": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"semver": "5.5.0"
+						"babel-generator": "^6.18.0",
+						"babel-template": "^6.16.0",
+						"babel-traverse": "^6.18.0",
+						"babel-types": "^6.18.0",
+						"babylon": "^6.18.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"semver": "^5.3.0"
 					}
 				},
 				"istanbul-lib-report": {
@@ -2123,10 +2124,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"path-parse": "1.0.5",
-						"supports-color": "3.2.3"
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"path-parse": "^1.0.5",
+						"supports-color": "^3.1.2"
 					},
 					"dependencies": {
 						"supports-color": {
@@ -2134,7 +2135,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"has-flag": "1.0.0"
+								"has-flag": "^1.0.0"
 							}
 						}
 					}
@@ -2144,11 +2145,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"debug": "3.1.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"source-map": "0.5.7"
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.6.1",
+						"source-map": "^0.5.3"
 					},
 					"dependencies": {
 						"debug": {
@@ -2166,7 +2167,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"handlebars": "4.0.11"
+						"handlebars": "^4.0.3"
 					}
 				},
 				"js-tokens": {
@@ -2184,7 +2185,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				},
 				"lazy-cache": {
@@ -2198,7 +2199,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -2206,11 +2207,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"locate-path": {
@@ -2218,8 +2219,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					},
 					"dependencies": {
 						"path-exists": {
@@ -2237,14 +2238,15 @@
 				"longest": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"loose-envify": {
 					"version": "1.3.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"js-tokens": "3.0.2"
+						"js-tokens": "^3.0.0"
 					}
 				},
 				"lru-cache": {
@@ -2252,8 +2254,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"map-cache": {
@@ -2266,7 +2268,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"object-visit": "1.0.1"
+						"object-visit": "^1.0.0"
 					}
 				},
 				"md5-hex": {
@@ -2274,7 +2276,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"md5-o-matic": "0.1.1"
+						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"md5-o-matic": {
@@ -2287,7 +2289,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"merge-source-map": {
@@ -2295,7 +2297,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"source-map": "0.6.1"
+						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
@@ -2310,19 +2312,19 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2342,7 +2344,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -2355,8 +2357,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"for-in": "1.0.2",
-						"is-extendable": "1.0.1"
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
@@ -2364,7 +2366,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -2387,18 +2389,18 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"fragment-cache": "0.2.1",
-						"is-odd": "2.0.0",
-						"is-windows": "1.0.2",
-						"kind-of": "6.0.2",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -2423,10 +2425,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "2.6.0",
-						"is-builtin-module": "1.0.0",
-						"semver": "5.5.0",
-						"validate-npm-package-license": "3.0.3"
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"npm-run-path": {
@@ -2434,7 +2436,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"path-key": "2.0.1"
+						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -2452,9 +2454,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"copy-descriptor": "0.1.1",
-						"define-property": "0.2.5",
-						"kind-of": "3.2.2"
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
 					},
 					"dependencies": {
 						"define-property": {
@@ -2462,7 +2464,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -2472,7 +2474,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -2487,7 +2489,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
@@ -2502,7 +2504,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"optimist": {
@@ -2510,8 +2512,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"minimist": "0.0.8",
-						"wordwrap": "0.0.3"
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
 					}
 				},
 				"os-homedir": {
@@ -2524,9 +2526,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
 				},
 				"p-finally": {
@@ -2539,7 +2541,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
@@ -2547,7 +2549,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-limit": "1.2.0"
+						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
@@ -2560,7 +2562,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.1"
+						"error-ex": "^1.2.0"
 					}
 				},
 				"pascalcase": {
@@ -2573,7 +2575,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-is-absolute": {
@@ -2596,9 +2598,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"pify": {
@@ -2616,7 +2618,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pinkie": "2.0.4"
+						"pinkie": "^2.0.0"
 					}
 				},
 				"pkg-dir": {
@@ -2624,7 +2626,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"find-up": "1.1.2"
+						"find-up": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
@@ -2632,8 +2634,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -2653,9 +2655,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -2663,8 +2665,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
@@ -2672,8 +2674,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -2688,8 +2690,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"extend-shallow": "3.0.2",
-						"safe-regex": "1.1.0"
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"repeat-element": {
@@ -2707,7 +2709,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-finite": "1.0.2"
+						"is-finite": "^1.0.0"
 					}
 				},
 				"require-directory": {
@@ -2741,7 +2743,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4"
+						"align-text": "^0.1.1"
 					}
 				},
 				"rimraf": {
@@ -2749,7 +2751,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-regex": {
@@ -2757,7 +2759,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ret": "0.1.15"
+						"ret": "~0.1.10"
 					}
 				},
 				"semver": {
@@ -2775,10 +2777,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"split-string": "3.1.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -2786,7 +2788,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2796,7 +2798,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"shebang-regex": "1.0.0"
+						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -2819,14 +2821,14 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"base": "0.11.2",
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"map-cache": "0.2.2",
-						"source-map": "0.5.7",
-						"source-map-resolve": "0.5.1",
-						"use": "3.1.0"
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
 					},
 					"dependencies": {
 						"define-property": {
@@ -2834,7 +2836,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -2842,7 +2844,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2852,9 +2854,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"snapdragon-util": "3.0.1"
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -2862,7 +2864,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -2870,7 +2872,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
@@ -2878,7 +2880,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
@@ -2886,9 +2888,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"isobject": {
@@ -2908,7 +2910,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.2.0"
 					}
 				},
 				"source-map": {
@@ -2921,11 +2923,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"atob": "2.1.1",
-						"decode-uri-component": "0.2.0",
-						"resolve-url": "0.2.1",
-						"source-map-url": "0.4.0",
-						"urix": "0.1.0"
+						"atob": "^2.0.0",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
 					}
 				},
 				"source-map-url": {
@@ -2938,12 +2940,12 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"foreground-child": "1.5.6",
-						"mkdirp": "0.5.1",
-						"os-homedir": "1.0.2",
-						"rimraf": "2.6.2",
-						"signal-exit": "3.0.2",
-						"which": "1.3.0"
+						"foreground-child": "^1.5.6",
+						"mkdirp": "^0.5.0",
+						"os-homedir": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.2",
+						"which": "^1.3.0"
 					}
 				},
 				"spdx-correct": {
@@ -2951,8 +2953,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-expression-parse": "3.0.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -2965,8 +2967,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-exceptions": "2.1.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -2979,7 +2981,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"extend-shallow": "3.0.2"
+						"extend-shallow": "^3.0.0"
 					}
 				},
 				"static-extend": {
@@ -2987,8 +2989,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"define-property": "0.2.5",
-						"object-copy": "0.1.0"
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
 					},
 					"dependencies": {
 						"define-property": {
@@ -2996,7 +2998,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						}
 					}
@@ -3006,8 +3008,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -3020,7 +3022,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						}
 					}
@@ -3030,7 +3032,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-bom": {
@@ -3038,7 +3040,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"strip-eof": {
@@ -3056,11 +3058,11 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arrify": "1.0.1",
-						"micromatch": "3.1.10",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"require-main-filename": "1.0.1"
+						"arrify": "^1.0.1",
+						"micromatch": "^3.1.8",
+						"object-assign": "^4.1.0",
+						"read-pkg-up": "^1.0.1",
+						"require-main-filename": "^1.0.1"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -3078,16 +3080,16 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arr-flatten": "1.1.0",
-								"array-unique": "0.3.2",
-								"extend-shallow": "2.0.1",
-								"fill-range": "4.0.0",
-								"isobject": "3.0.1",
-								"repeat-element": "1.1.2",
-								"snapdragon": "0.8.2",
-								"snapdragon-node": "2.1.1",
-								"split-string": "3.1.0",
-								"to-regex": "3.0.2"
+								"arr-flatten": "^1.1.0",
+								"array-unique": "^0.3.2",
+								"extend-shallow": "^2.0.1",
+								"fill-range": "^4.0.0",
+								"isobject": "^3.0.1",
+								"repeat-element": "^1.1.2",
+								"snapdragon": "^0.8.1",
+								"snapdragon-node": "^2.0.1",
+								"split-string": "^3.0.2",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"extend-shallow": {
@@ -3095,7 +3097,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -3105,13 +3107,13 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"debug": "2.6.9",
-								"define-property": "0.2.5",
-								"extend-shallow": "2.0.1",
-								"posix-character-classes": "0.1.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"debug": "^2.3.3",
+								"define-property": "^0.2.5",
+								"extend-shallow": "^2.0.1",
+								"posix-character-classes": "^0.1.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
@@ -3119,7 +3121,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "0.1.6"
+										"is-descriptor": "^0.1.0"
 									}
 								},
 								"extend-shallow": {
@@ -3127,7 +3129,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								},
 								"is-accessor-descriptor": {
@@ -3135,7 +3137,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
@@ -3143,7 +3145,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -3153,7 +3155,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"kind-of": "3.2.2"
+										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
@@ -3161,7 +3163,7 @@
 											"bundled": true,
 											"dev": true,
 											"requires": {
-												"is-buffer": "1.1.6"
+												"is-buffer": "^1.1.5"
 											}
 										}
 									}
@@ -3171,9 +3173,9 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-accessor-descriptor": "0.1.6",
-										"is-data-descriptor": "0.1.4",
-										"kind-of": "5.1.0"
+										"is-accessor-descriptor": "^0.1.6",
+										"is-data-descriptor": "^0.1.4",
+										"kind-of": "^5.0.0"
 									}
 								},
 								"kind-of": {
@@ -3188,14 +3190,14 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"array-unique": "0.3.2",
-								"define-property": "1.0.0",
-								"expand-brackets": "2.1.4",
-								"extend-shallow": "2.0.1",
-								"fragment-cache": "0.2.1",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"array-unique": "^0.3.2",
+								"define-property": "^1.0.0",
+								"expand-brackets": "^2.1.4",
+								"extend-shallow": "^2.0.1",
+								"fragment-cache": "^0.2.1",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
 							},
 							"dependencies": {
 								"define-property": {
@@ -3203,7 +3205,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-descriptor": "1.0.2"
+										"is-descriptor": "^1.0.0"
 									}
 								},
 								"extend-shallow": {
@@ -3211,7 +3213,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -3221,10 +3223,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-number": "3.0.0",
-								"repeat-string": "1.6.1",
-								"to-regex-range": "2.1.1"
+								"extend-shallow": "^2.0.1",
+								"is-number": "^3.0.0",
+								"repeat-string": "^1.6.1",
+								"to-regex-range": "^2.1.0"
 							},
 							"dependencies": {
 								"extend-shallow": {
@@ -3232,7 +3234,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-extendable": "0.1.1"
+										"is-extendable": "^0.1.0"
 									}
 								}
 							}
@@ -3242,7 +3244,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
@@ -3250,7 +3252,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "6.0.2"
+								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
@@ -3258,9 +3260,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
 							}
 						},
 						"is-number": {
@@ -3268,7 +3270,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -3276,7 +3278,7 @@
 									"bundled": true,
 									"dev": true,
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -3296,19 +3298,19 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"arr-diff": "4.0.0",
-								"array-unique": "0.3.2",
-								"braces": "2.3.2",
-								"define-property": "2.0.2",
-								"extend-shallow": "3.0.2",
-								"extglob": "2.0.4",
-								"fragment-cache": "0.2.1",
-								"kind-of": "6.0.2",
-								"nanomatch": "1.2.9",
-								"object.pick": "1.3.0",
-								"regex-not": "1.0.2",
-								"snapdragon": "0.8.2",
-								"to-regex": "3.0.2"
+								"arr-diff": "^4.0.0",
+								"array-unique": "^0.3.2",
+								"braces": "^2.3.1",
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"extglob": "^2.0.4",
+								"fragment-cache": "^0.2.1",
+								"kind-of": "^6.0.2",
+								"nanomatch": "^1.2.9",
+								"object.pick": "^1.3.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.2"
 							}
 						}
 					}
@@ -3323,7 +3325,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"to-regex": {
@@ -3331,10 +3333,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"regex-not": "1.0.2",
-						"safe-regex": "1.1.0"
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"to-regex-range": {
@@ -3342,8 +3344,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1"
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
 					},
 					"dependencies": {
 						"is-number": {
@@ -3351,7 +3353,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						}
 					}
@@ -3367,9 +3369,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"source-map": "0.5.7",
-						"uglify-to-browserify": "1.0.2",
-						"yargs": "3.10.0"
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
 					},
 					"dependencies": {
 						"yargs": {
@@ -3378,9 +3380,9 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"camelcase": "1.2.1",
-								"cliui": "2.1.0",
-								"decamelize": "1.2.0",
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
 								"window-size": "0.1.0"
 							}
 						}
@@ -3397,10 +3399,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arr-union": "3.1.0",
-						"get-value": "2.0.6",
-						"is-extendable": "0.1.1",
-						"set-value": "0.4.3"
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -3408,7 +3410,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"set-value": {
@@ -3416,10 +3418,10 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-extendable": "0.1.1",
-								"is-plain-object": "2.0.4",
-								"to-object-path": "0.3.0"
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
 							}
 						}
 					}
@@ -3429,8 +3431,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"has-value": "0.3.1",
-						"isobject": "3.0.1"
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"has-value": {
@@ -3438,9 +3440,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"get-value": "2.0.6",
-								"has-values": "0.1.4",
-								"isobject": "2.1.0"
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -3475,7 +3477,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -3490,8 +3492,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-correct": "3.0.0",
-						"spdx-expression-parse": "3.0.0"
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
 					}
 				},
 				"which": {
@@ -3499,7 +3501,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"isexe": "2.0.0"
+						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
@@ -3523,8 +3525,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					},
 					"dependencies": {
 						"is-fullwidth-code-point": {
@@ -3532,7 +3534,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
@@ -3540,9 +3542,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						}
 					}
@@ -3557,9 +3559,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"slide": "1.1.6"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
 					}
 				},
 				"y18n": {
@@ -3577,18 +3579,18 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cliui": "4.1.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "9.0.2"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -3606,9 +3608,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"string-width": "2.1.1",
-								"strip-ansi": "4.0.0",
-								"wrap-ansi": "2.1.0"
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
 							}
 						},
 						"strip-ansi": {
@@ -3616,7 +3618,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "3.0.0"
+								"ansi-regex": "^3.0.0"
 							}
 						},
 						"yargs-parser": {
@@ -3624,7 +3626,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"camelcase": "4.1.0"
+								"camelcase": "^4.1.0"
 							}
 						}
 					}
@@ -3634,7 +3636,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -3670,10 +3672,10 @@
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.3",
-				"function-bind": "1.1.1",
-				"has-symbols": "1.0.1",
-				"object-keys": "1.1.1"
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
 			}
 		},
 		"once": {
@@ -3682,7 +3684,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"os-locale": {
@@ -3691,9 +3693,9 @@
 			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
 			"dev": true,
 			"requires": {
-				"execa": "1.0.0",
-				"lcid": "2.0.0",
-				"mem": "4.3.0"
+				"execa": "^1.0.0",
+				"lcid": "^2.0.0",
+				"mem": "^4.0.0"
 			}
 		},
 		"p-defer": {
@@ -3720,7 +3722,7 @@
 			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 			"dev": true,
 			"requires": {
-				"p-try": "1.0.0"
+				"p-try": "^1.0.0"
 			}
 		},
 		"p-locate": {
@@ -3729,7 +3731,7 @@
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "1.3.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-try": {
@@ -3744,8 +3746,8 @@
 			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"dev": true,
 			"requires": {
-				"error-ex": "1.3.2",
-				"json-parse-better-errors": "1.0.2"
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
 			}
 		},
 		"path-exists": {
@@ -3787,7 +3789,7 @@
 			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"dev": true,
 			"requires": {
-				"pify": "3.0.0"
+				"pify": "^3.0.0"
 			}
 		},
 		"pathval": {
@@ -3808,8 +3810,8 @@
 			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "1.4.4",
-				"once": "1.4.0"
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
 			}
 		},
 		"q": {
@@ -3828,9 +3830,9 @@
 			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "4.0.0",
-				"normalize-package-data": "2.5.0",
-				"path-type": "3.0.0"
+				"load-json-file": "^4.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^3.0.0"
 			}
 		},
 		"reflect-metadata": {
@@ -3845,8 +3847,8 @@
 			"integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.3",
-				"es-abstract": "1.17.0"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1"
 			}
 		},
 		"require-directory": {
@@ -3867,7 +3869,7 @@
 			"integrity": "sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==",
 			"dev": true,
 			"requires": {
-				"path-parse": "1.0.6"
+				"path-parse": "^1.0.6"
 			}
 		},
 		"rx": {
@@ -3900,7 +3902,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -3921,13 +3923,13 @@
 			"integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "2.0.0",
-				"diff": "3.5.0",
-				"lodash.get": "4.4.2",
-				"lolex": "2.7.5",
-				"nise": "1.5.3",
-				"supports-color": "5.5.0",
-				"type-detect": "4.0.8"
+				"@sinonjs/formatio": "^2.0.0",
+				"diff": "^3.1.0",
+				"lodash.get": "^4.4.2",
+				"lolex": "^2.2.0",
+				"nise": "^1.2.0",
+				"supports-color": "^5.1.0",
+				"type-detect": "^4.0.5"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -3936,7 +3938,7 @@
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -3953,8 +3955,8 @@
 			"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "1.1.1",
-				"source-map": "0.6.1"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"spawn-command": {
@@ -3969,8 +3971,8 @@
 			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
 			"dev": true,
 			"requires": {
-				"spdx-expression-parse": "3.0.0",
-				"spdx-license-ids": "3.0.5"
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-exceptions": {
@@ -3985,8 +3987,8 @@
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"dev": true,
 			"requires": {
-				"spdx-exceptions": "2.2.0",
-				"spdx-license-ids": "3.0.5"
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-license-ids": {
@@ -4007,8 +4009,8 @@
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0",
-				"strip-ansi": "4.0.0"
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
 			}
 		},
 		"string.prototype.trimleft": {
@@ -4017,8 +4019,8 @@
 			"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.3",
-				"function-bind": "1.1.1"
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
 			}
 		},
 		"string.prototype.trimright": {
@@ -4027,8 +4029,8 @@
 			"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.3",
-				"function-bind": "1.1.1"
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
 			}
 		},
 		"strip-ansi": {
@@ -4037,7 +4039,7 @@
 			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "3.0.0"
+				"ansi-regex": "^3.0.0"
 			}
 		},
 		"strip-bom": {
@@ -4058,7 +4060,7 @@
 			"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 			"dev": true,
 			"requires": {
-				"has-flag": "1.0.0"
+				"has-flag": "^1.0.0"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -4081,14 +4083,14 @@
 			"integrity": "sha512-ZNT+OEGfUNVMGkpIaDJJ44Zq3Yr0bkU/ugN1PHbU+/01Z7UV1fsELRiTx1KuQNvQ1A3pGh3y25iYF6jXgxV21A==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"buffer-from": "1.1.1",
-				"diff": "3.5.0",
-				"make-error": "1.3.5",
-				"minimist": "1.2.0",
-				"mkdirp": "0.5.1",
-				"source-map-support": "0.5.16",
-				"yn": "2.0.0"
+				"arrify": "^1.0.0",
+				"buffer-from": "^1.1.0",
+				"diff": "^3.1.0",
+				"make-error": "^1.1.1",
+				"minimist": "^1.2.0",
+				"mkdirp": "^0.5.1",
+				"source-map-support": "^0.5.6",
+				"yn": "^2.0.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -4111,19 +4113,19 @@
 			"integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.5.5",
-				"builtin-modules": "1.1.1",
-				"chalk": "2.4.2",
-				"commander": "2.20.3",
-				"diff": "4.0.1",
-				"glob": "7.1.2",
-				"js-yaml": "3.13.1",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"resolve": "1.14.1",
-				"semver": "5.7.1",
-				"tslib": "1.10.0",
-				"tsutils": "2.29.0"
+				"@babel/code-frame": "^7.0.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^4.0.1",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.13.1",
+				"minimatch": "^3.0.4",
+				"mkdirp": "^0.5.1",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.29.0"
 			},
 			"dependencies": {
 				"commander": {
@@ -4146,9 +4148,9 @@
 			"integrity": "sha512-mUpHPTeeCFx8XARGG/kzYP4dPSOgoCqNiYbGHh09qTH8q+Y1ghsOgaeZKYYQT7IyxMos523z/QBaiv2zKNBcow==",
 			"dev": true,
 			"requires": {
-				"tslint-consistent-codestyle": "1.16.0",
-				"tslint-eslint-rules": "5.4.0",
-				"tslint-microsoft-contrib": "5.2.1"
+				"tslint-consistent-codestyle": "^1.14.1",
+				"tslint-eslint-rules": "^5.4.0",
+				"tslint-microsoft-contrib": "~5.2.1"
 			}
 		},
 		"tslint-consistent-codestyle": {
@@ -4157,9 +4159,9 @@
 			"integrity": "sha512-ebR/xHyMEuU36hGNOgCfjGBNYxBPixf0yU1Yoo6s3BrpBRFccjPOmIVaVvQsWAUAMdmfzHOCihVkcaMfimqvHw==",
 			"dev": true,
 			"requires": {
-				"@fimbul/bifrost": "0.21.0",
-				"tslib": "1.10.0",
-				"tsutils": "2.29.0"
+				"@fimbul/bifrost": "^0.21.0",
+				"tslib": "^1.7.1",
+				"tsutils": "^2.29.0"
 			}
 		},
 		"tslint-eslint-rules": {
@@ -4170,7 +4172,7 @@
 			"requires": {
 				"doctrine": "0.7.2",
 				"tslib": "1.9.0",
-				"tsutils": "3.17.1"
+				"tsutils": "^3.0.0"
 			},
 			"dependencies": {
 				"tslib": {
@@ -4185,7 +4187,7 @@
 					"integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
 					"dev": true,
 					"requires": {
-						"tslib": "1.9.0"
+						"tslib": "^1.8.1"
 					}
 				}
 			}
@@ -4196,7 +4198,7 @@
 			"integrity": "sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==",
 			"dev": true,
 			"requires": {
-				"tsutils": "2.28.0"
+				"tsutils": "^2.27.2 <2.29.0"
 			},
 			"dependencies": {
 				"tsutils": {
@@ -4205,7 +4207,7 @@
 					"integrity": "sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==",
 					"dev": true,
 					"requires": {
-						"tslib": "1.10.0"
+						"tslib": "^1.8.1"
 					}
 				}
 			}
@@ -4216,7 +4218,7 @@
 			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
 			"dev": true,
 			"requires": {
-				"tslib": "1.10.0"
+				"tslib": "^1.8.1"
 			}
 		},
 		"type-detect": {
@@ -4242,8 +4244,8 @@
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "3.1.0",
-				"spdx-expression-parse": "3.0.0"
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"which": {
@@ -4252,7 +4254,7 @@
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"dev": true,
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"which-module": {
@@ -4267,8 +4269,8 @@
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4283,7 +4285,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"string-width": {
@@ -4292,9 +4294,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -4303,7 +4305,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				}
 			}
@@ -4326,18 +4328,18 @@
 			"integrity": "sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==",
 			"dev": true,
 			"requires": {
-				"cliui": "4.1.0",
-				"decamelize": "1.2.0",
-				"find-up": "2.1.0",
-				"get-caller-file": "1.0.3",
-				"os-locale": "3.1.0",
-				"require-directory": "2.1.1",
-				"require-main-filename": "1.0.1",
-				"set-blocking": "2.0.0",
-				"string-width": "2.1.1",
-				"which-module": "2.0.0",
-				"y18n": "3.2.1",
-				"yargs-parser": "9.0.2"
+				"cliui": "^4.0.0",
+				"decamelize": "^1.1.1",
+				"find-up": "^2.1.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^3.1.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1",
+				"yargs-parser": "^9.0.2"
 			}
 		},
 		"yargs-parser": {
@@ -4346,7 +4348,7 @@
 			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "4.1.0"
+				"camelcase": "^4.1.0"
 			}
 		},
 		"yn": {

--- a/package.json
+++ b/package.json
@@ -1,114 +1,114 @@
 {
-	"name": "channelape-sdk",
-	"version": "1.22.0-develop.0",
-	"description": "A client for interacting with ChannelApe's API",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"scripts": {
-		"prepack": "npm run compile",
-		"prepublishOnly": "npm run compile",
-		"compile": "tsc && tsc -p test/tsconfig.json && tsc -p e2e/tsconfig.json",
-		"watch": "concurrently -k -p \"[{name}]\" -n \"src,test,e2e\" -c \"yellow.bold,cyan.bold,green.bold\" \"tsc --watch\" \"tsc -p test/tsconfig.json --watch\" \"tsc -p e2e/tsconfig.json --watch\"",
-		"unit-test": "mocha --opts ./test/mocha.opts",
-		"watch-unit-test": "mocha --recursive --compilers ts:ts-node/register --watch test/**/*.spec.* ",
-		"test": "npm run unit-test",
-		"pretest": "npm run compile && npm run lint",
-		"posttest": "npm run cover",
-		"cover": "nyc npm run unit-test && nyc check-coverage --lines 90 --branches 90 --statements 90 --functions 90",
-		"lint": "tslint -p tsconfig.json && tslint -p test/tsconfig.json && tslint -p e2e/tsconfig.json",
-		"e2e": "mocha --opts ./e2e/mocha.opts"
-	},
-	"files": [
-		"dist"
-	],
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/ChannelApe/channelape-typescript-sdk.git"
-	},
-	"keywords": [
-		"channelape",
-		"sdk",
-		"javascript",
-		"typescript",
-		"ecommerce",
-		"rest-client"
-	],
-	"publishConfig": {
-		"access": "public"
-	},
-	"author": "ChannelApe",
-	"license": "Apache-2.0",
-	"bugs": {
-		"url": "https://github.com/ChannelApe/channelape-typescript-sdk/issues"
-	},
-	"homepage": "https://github.com/ChannelApe/channelape-typescript-sdk#readme",
-	"contributors": [
-		{
-			"name": "Michael Bates",
-			"email": "mbates@channelape.com"
-		},
-		{
-			"name": "RJ Davis",
-			"email": "rjdavis@channelape.com"
-		},
-		{
-			"name": "Ryan Kazokas",
-			"email": "rkazokas@channelape.com"
-		},
-		{
-			"name": "Frank Mazzarella",
-			"email": "fmazzarella@channelape.com"
-		},
-		{
-			"name": "Craig Simko",
-			"email": "csimko@channelape.com"
-		}
-	],
-	"dependencies": {
-		"axios": "^0.18.1",
-		"channelape-logger": "^0.2.0",
-		"q": "1.5.1",
-		"qs": "^6.9.1",
-		"uuid": "^3.3.3"
-	},
-	"devDependencies": {
-		"@types/app-root-path": "^1.2.4",
-		"@types/axios": "^0.14.0",
-		"@types/chai": "^4.1.3",
-		"@types/faker": "^4.1.4",
-		"@types/mocha": "^5.2.0",
-		"@types/node": "^10.7.0",
-		"@types/q": "^1.5.0",
-		"@types/qs": "^6.9.0",
-		"@types/sinon": "^4.3.1",
-		"@types/uuid": "^3.4.6",
-		"app-root-path": "^2.1.0",
-		"axios-mock-adapter": "^1.15.0",
-		"chai": "^4.1.2",
-		"concurrently": "^3.5.1",
-		"faker": "^4.1.0",
-		"mocha": "^5.1.1",
-		"mocha-typescript": "^1.1.12",
-		"nyc": "^11.7.1",
-		"sinon": "^4.5.0",
-		"source-map-support": "^0.5.5",
-		"ts-node": "^6.0.1",
-		"tslint": "^5.9.1",
-		"tslint-config-airbnb": "^5.8.0",
-		"typescript": "^2.8.4"
-	},
-	"nyc": {
-		"include": [
-			"src/**/*.ts"
-		],
-		"extension": [
-			".ts"
-		],
-		"reporter": [
-			"lcov",
-			"text",
-			"text-summary"
-		],
-		"report-dir": "./reports/lcov"
-	}
+  "name": "channelape-sdk",
+  "version": "1.22.0-test.0",
+  "description": "A client for interacting with ChannelApe's API",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "prepack": "npm run compile",
+    "prepublishOnly": "npm run compile",
+    "compile": "tsc && tsc -p test/tsconfig.json && tsc -p e2e/tsconfig.json",
+    "watch": "concurrently -k -p \"[{name}]\" -n \"src,test,e2e\" -c \"yellow.bold,cyan.bold,green.bold\" \"tsc --watch\" \"tsc -p test/tsconfig.json --watch\" \"tsc -p e2e/tsconfig.json --watch\"",
+    "unit-test": "mocha --opts ./test/mocha.opts",
+    "watch-unit-test": "mocha --recursive --compilers ts:ts-node/register --watch test/**/*.spec.* ",
+    "test": "npm run unit-test",
+    "pretest": "npm run compile && npm run lint",
+    "posttest": "npm run cover",
+    "cover": "nyc npm run unit-test && nyc check-coverage --lines 90 --branches 90 --statements 90 --functions 90",
+    "lint": "tslint -p tsconfig.json && tslint -p test/tsconfig.json && tslint -p e2e/tsconfig.json",
+    "e2e": "mocha --opts ./e2e/mocha.opts"
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ChannelApe/channelape-typescript-sdk.git"
+  },
+  "keywords": [
+    "channelape",
+    "sdk",
+    "javascript",
+    "typescript",
+    "ecommerce",
+    "rest-client"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "ChannelApe",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/ChannelApe/channelape-typescript-sdk/issues"
+  },
+  "homepage": "https://github.com/ChannelApe/channelape-typescript-sdk#readme",
+  "contributors": [
+    {
+      "name": "Michael Bates",
+      "email": "mbates@channelape.com"
+    },
+    {
+      "name": "RJ Davis",
+      "email": "rjdavis@channelape.com"
+    },
+    {
+      "name": "Ryan Kazokas",
+      "email": "rkazokas@channelape.com"
+    },
+    {
+      "name": "Frank Mazzarella",
+      "email": "fmazzarella@channelape.com"
+    },
+    {
+      "name": "Craig Simko",
+      "email": "csimko@channelape.com"
+    }
+  ],
+  "dependencies": {
+    "axios": "^0.18.1",
+    "channelape-logger": "^0.2.0",
+    "q": "1.5.1",
+    "qs": "^6.9.1",
+    "uuid": "^3.3.3"
+  },
+  "devDependencies": {
+    "@types/app-root-path": "^1.2.4",
+    "@types/axios": "^0.14.0",
+    "@types/chai": "^4.1.3",
+    "@types/faker": "^4.1.4",
+    "@types/mocha": "^5.2.0",
+    "@types/node": "^10.7.0",
+    "@types/q": "^1.5.0",
+    "@types/qs": "^6.9.0",
+    "@types/sinon": "^4.3.1",
+    "@types/uuid": "^3.4.6",
+    "app-root-path": "^2.1.0",
+    "axios-mock-adapter": "^1.15.0",
+    "chai": "^4.1.2",
+    "concurrently": "^3.5.1",
+    "faker": "^4.1.0",
+    "mocha": "^5.1.1",
+    "mocha-typescript": "^1.1.12",
+    "nyc": "^11.7.1",
+    "sinon": "^4.5.0",
+    "source-map-support": "^0.5.5",
+    "ts-node": "^6.0.1",
+    "tslint": "^5.9.1",
+    "tslint-config-airbnb": "^5.8.0",
+    "typescript": "^2.8.4"
+  },
+  "nyc": {
+    "include": [
+      "src/**/*.ts"
+    ],
+    "extension": [
+      ".ts"
+    ],
+    "reporter": [
+      "lcov",
+      "text",
+      "text-summary"
+    ],
+    "report-dir": "./reports/lcov"
+  }
 }

--- a/src/orders/model/LineItem.ts
+++ b/src/orders/model/LineItem.ts
@@ -13,6 +13,7 @@ export default interface LineItem {
   upc?: string;
   title?: string;
   vendor?: string;
+  restockType?: string;
   readonly giftCardCode?: string;
   readonly giftCardId?: string;
 }

--- a/test/orders/resources/singleOrder.ts
+++ b/test/orders/resources/singleOrder.ts
@@ -275,6 +275,26 @@ const singleOrder: Order = {
       vendor: 'Hand, Swift and Langosh'
     }
   ],
+  refunds: [
+    {
+      supplierRefundId: "932",
+      channelRefundId: "123",
+      lineItems: [
+        {
+          id: "123",
+          sku: "ABC-123",
+          quantity: 6,
+          restockType: "CANCEL"
+        },
+        {
+          id: "124",
+          sku: "ABC-124",
+          quantity: 13,
+          restockType: "NO_RESTOCK"
+        }
+      ]
+    }
+  ],
   purchasedAt: new Date('2018-03-29T19:06:26.000Z'),
   status: OrderStatus.OPEN,
   subtotalPrice: 25.98,

--- a/test/orders/resources/singleOrder.ts
+++ b/test/orders/resources/singleOrder.ts
@@ -277,20 +277,20 @@ const singleOrder: Order = {
   ],
   refunds: [
     {
-      supplierRefundId: "932",
-      channelRefundId: "123",
+      supplierRefundId: '932',
+      channelRefundId: '123',
       lineItems: [
         {
-          id: "123",
-          sku: "ABC-123",
+          id: '123',
+          sku: 'ABC-123',
           quantity: 6,
-          restockType: "CANCEL"
+          restockType: 'CANCEL'
         },
         {
-          id: "124",
-          sku: "ABC-124",
+          id: '124',
+          sku: 'ABC-124',
           quantity: 13,
-          restockType: "NO_RESTOCK"
+          restockType: 'NO_RESTOCK'
         }
       ]
     }

--- a/test/orders/resources/singleOrderJson.json
+++ b/test/orders/resources/singleOrderJson.json
@@ -159,6 +159,26 @@
       "provinceCode": "KS"
     }
   },
+  "refunds": [
+    {
+      "supplierRefundId": "932",
+      "channelRefundId": "123",
+      "lineItems": [
+        {
+          "id": "123",
+          "sku": "ABC-123",
+          "quantity": 6,
+          "restockType": "CANCEL"
+        },
+        {
+          "id": "124",
+          "sku": "ABC-124",
+          "quantity": 13,
+          "restockType": "NO_RESTOCK"
+        }
+      ]
+    }
+  ],
   "fulfillments": [],
   "id": "c0f45529-cbed-4e90-9a38-c208d409ef2a",
   "lineItems": [

--- a/test/orders/service/OrdersService.spec.ts
+++ b/test/orders/service/OrdersService.spec.ts
@@ -45,7 +45,8 @@ const ordersService: OrdersService = new OrdersService(clientWrapper);
 
 describe('OrdersService', () => {
   describe('Given some valid rest client', () => {
-    it(`And valid orderId
+
+    it.only(`And valid orderId
             When retrieving order Then return resolved promise with order`, () => {
       const orderId = 'c0f45529-cbed-4e90-9a38-c208d409ef2a';
       const mockedAxiosAdapter = new axiosMockAdapter(axios);
@@ -57,6 +58,27 @@ describe('OrdersService', () => {
         expect(actualOrder.purchaseOrderNumber).to.equal(singleOrder.purchaseOrderNumber);
         expect(typeof actualOrder.totalShippingTax).to.equal('undefined');
         expect(typeof actualOrder.canceledAt).to.equal('undefined');
+        // @ts-ignore
+        expect(actualOrder.refunds.length).to.equal(1);
+        // @ts-ignore
+        const expectedRefund = singleOrder.refunds[0];
+        // @ts-ignore
+        const actualRefund1 = actualOrder.refunds[0];
+        expect(actualRefund1.channelRefundId).to.equal(expectedRefund.channelRefundId);
+        expect(actualRefund1.supplierRefundId).to.equal(expectedRefund.supplierRefundId);
+        expect(2).to.equal(expectedRefund.lineItems.length);
+        expect(actualRefund1.lineItems[0].sku).to.equal(expectedRefund.lineItems[0].sku);
+        expect(actualRefund1.lineItems[0].upc).to.equal(expectedRefund.lineItems[0].upc);
+        expect(actualRefund1.lineItems[0].quantity).to.equal(expectedRefund.lineItems[0].quantity);
+        expect(actualRefund1.lineItems[0].id).to.equal(expectedRefund.lineItems[0].id);
+        expect(actualRefund1.lineItems[0].price).to.equal(expectedRefund.lineItems[0].price);
+        expect(actualRefund1.lineItems[0].restockType).to.equal(expectedRefund.lineItems[0].restockType);
+        expect(actualRefund1.lineItems[1].sku).to.equal(expectedRefund.lineItems[1].sku);
+        expect(actualRefund1.lineItems[1].upc).to.equal(expectedRefund.lineItems[1].upc);
+        expect(actualRefund1.lineItems[1].quantity).to.equal(expectedRefund.lineItems[1].quantity);
+        expect(actualRefund1.lineItems[1].id).to.equal(expectedRefund.lineItems[1].id);
+        expect(actualRefund1.lineItems[1].price).to.equal(expectedRefund.lineItems[1].price);
+        expect(actualRefund1.lineItems[1].restockType).to.equal(expectedRefund.lineItems[1].restockType);
       });
     });
 
@@ -137,9 +159,9 @@ describe('OrdersService', () => {
       return ordersService.get(orderId).then((actualOrder) => {
         throw new Error('Test failed!');
       })
-      .catch((e: ChannelApeError) => {
-        expect(e.message).to.be.an('string');
-      });
+        .catch((e: ChannelApeError) => {
+          expect(e.message).to.be.an('string');
+        });
     });
 
     it(`And valid businessId and channelOrderId
@@ -355,7 +377,7 @@ describe('OrdersService', () => {
             When retrieving order Then return rejected promise with ChannelApeError`, () => {
       // tslint:disable:no-trailing-whitespace
       const expectedErrorMessage =
-`get /v1/orders
+        `get /v1/orders
   Status: 404
   Response Body:
   Request failed with status code 404
@@ -364,7 +386,7 @@ Code: 15 Message: Requested business cannot be found.`;
       const mockedAxiosAdapter = new axiosMockAdapter(axios);
       mockedAxiosAdapter.onGet().reply(404, {
         statusCode: 404,
-        errors:[{ code: 15, message: 'Requested business cannot be found.' }]
+        errors: [{ code: 15, message: 'Requested business cannot be found.' }]
       });
 
       const businessId = 'not-a-real-business-id';
@@ -374,9 +396,9 @@ Code: 15 Message: Requested business cannot be found.`;
       return ordersService.get(requestOptions).then((actualOrders) => {
         throw new Error('Test failed!');
       })
-      .catch((e: ChannelApeError) => {
-        expect(e.message).to.equal(expectedErrorMessage);
-      });
+        .catch((e: ChannelApeError) => {
+          expect(e.message).to.equal(expectedErrorMessage);
+        });
     });
 
     it(`And valid order when updating said order with an actionId
@@ -507,7 +529,7 @@ Code: 15 Message: Requested business cannot be found.`;
       });
     });
 
-    it('And valid OrderCreateRequest with an actionId when creating an order, Then return created order', () => {
+    it.only('And valid OrderCreateRequest with an actionId when creating an order, Then return created order', () => {
       const orderCreateRequest: OrderCreateRequest = JSON.parse(JSON.stringify(singleOrder));
       orderCreateRequest.actionId = 'some-action-id';
       orderCreateRequest.fulfillments!.push({
@@ -537,6 +559,27 @@ Code: 15 Message: Requested business cannot be found.`;
         expect(createdOrder.fulfillments![0].lineItems.length).to.equal(2, 'fulfillments.lineItems.length');
         expect(createdOrder.fulfillments![0].lineItems[0].sku)
           .to.equal('e67f1d90-824a-4941-8497-08d632763c93', 'fulfillments.lineItems.sku');
+        // @ts-ignore
+        expect(createdOrder.refunds.length).to.equal(1);
+        // @ts-ignore
+        const expectedRefund = singleOrder.refunds[0];
+        // @ts-ignore
+        const actualRefund1 = createdOrder.refunds[0];
+        expect(actualRefund1.channelRefundId).to.equal(expectedRefund.channelRefundId);
+        expect(actualRefund1.supplierRefundId).to.equal(expectedRefund.supplierRefundId);
+        expect(2).to.equal(expectedRefund.lineItems.length);
+        expect(actualRefund1.lineItems[0].sku).to.equal(expectedRefund.lineItems[0].sku);
+        expect(actualRefund1.lineItems[0].upc).to.equal(expectedRefund.lineItems[0].upc);
+        expect(actualRefund1.lineItems[0].quantity).to.equal(expectedRefund.lineItems[0].quantity);
+        expect(actualRefund1.lineItems[0].id).to.equal(expectedRefund.lineItems[0].id);
+        expect(actualRefund1.lineItems[0].price).to.equal(expectedRefund.lineItems[0].price);
+        expect(actualRefund1.lineItems[0].restockType).to.equal(expectedRefund.lineItems[0].restockType);
+        expect(actualRefund1.lineItems[1].sku).to.equal(expectedRefund.lineItems[1].sku);
+        expect(actualRefund1.lineItems[1].upc).to.equal(expectedRefund.lineItems[1].upc);
+        expect(actualRefund1.lineItems[1].quantity).to.equal(expectedRefund.lineItems[1].quantity);
+        expect(actualRefund1.lineItems[1].id).to.equal(expectedRefund.lineItems[1].id);
+        expect(actualRefund1.lineItems[1].price).to.equal(expectedRefund.lineItems[1].price);
+        expect(actualRefund1.lineItems[1].restockType).to.equal(expectedRefund.lineItems[1].restockType);
       });
     });
 
@@ -578,15 +621,16 @@ Code: 15 Message: Requested business cannot be found.`;
     it(`And invalid orderId
             When retrieving order Then return rejected promise with ChannelApeError`, () => {
       const expectedErrorMessage =
-`get /v1/orders/not-a-real-order-id
+        `get /v1/orders/not-a-real-order-id
   Status: 401
   Response Body:
   Request failed with status code 401
 Code: 12 Message: Invalid authorization token. Please check the server logs and try again`;
       const mockedAxiosAdapter = new axiosMockAdapter(axios);
       mockedAxiosAdapter.onGet().reply(401,
-        { errors:
-          [{ code: 12, message: 'Invalid authorization token. Please check the server logs and try again' }]
+        {
+          errors:
+            [{ code: 12, message: 'Invalid authorization token. Please check the server logs and try again' }]
         });
       const client: RequestClientWrapper = new RequestClientWrapper({
         endpoint: 'this-is-not-a-real-base-url',
@@ -603,9 +647,9 @@ Code: 12 Message: Invalid authorization token. Please check the server logs and 
       return ordersService.get(orderId).then((actualOrder) => {
         throw new Error('Test failed!');
       })
-      .catch((e) => {
-        expect(e.message).to.equal(expectedErrorMessage);
-      });
+        .catch((e) => {
+          expect(e.message).to.equal(expectedErrorMessage);
+        });
     });
 
     it(`And invalid businessId
@@ -621,7 +665,7 @@ Code: 12 Message: Invalid authorization token. Please check the server logs and 
         maximumConcurrentConnections: 5
       });
       const expectedErrorMessage =
-`get /v1/orders
+        `get /v1/orders
   Status: 401
   Response Body:
   Request failed with status code 401
@@ -634,9 +678,9 @@ Code: 12 Message: Invalid authorization token. Please check the server logs and 
       return ordersService.get(requestOptions).then((actualOrders) => {
         throw new Error('Test failed!');
       })
-      .catch((e) => {
-        expect(e.message).to.equal(expectedErrorMessage);
-      });
+        .catch((e) => {
+          expect(e.message).to.equal(expectedErrorMessage);
+        });
     });
   });
 });

--- a/test/orders/service/OrdersService.spec.ts
+++ b/test/orders/service/OrdersService.spec.ts
@@ -46,7 +46,7 @@ const ordersService: OrdersService = new OrdersService(clientWrapper);
 describe('OrdersService', () => {
   describe('Given some valid rest client', () => {
 
-    it.only(`And valid orderId
+    it(`And valid orderId
             When retrieving order Then return resolved promise with order`, () => {
       const orderId = 'c0f45529-cbed-4e90-9a38-c208d409ef2a';
       const mockedAxiosAdapter = new axiosMockAdapter(axios);
@@ -529,7 +529,7 @@ Code: 15 Message: Requested business cannot be found.`;
       });
     });
 
-    it.only('And valid OrderCreateRequest with an actionId when creating an order, Then return created order', () => {
+    it('And valid OrderCreateRequest with an actionId when creating an order, Then return created order', () => {
       const orderCreateRequest: OrderCreateRequest = JSON.parse(JSON.stringify(singleOrder));
       orderCreateRequest.actionId = 'some-action-id';
       orderCreateRequest.fulfillments!.push({


### PR DESCRIPTION
We could make a new object and extend the line item so that only the refunds have the restock type since that how the API will support it, but I didn't know if we should introduce breaking changes for this or not.