### PR TITLE
Converts number tax objects to actual numbers instead of strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "channelape-sdk",
-  "version": "1.28.0-develop.0",
+  "version": "1.28.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "channelape-sdk",
-  "version": "1.28.0",
+  "version": "1.28.1-develop.0",
   "description": "A client for interacting with ChannelApe's API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "channelape-sdk",
-  "version": "1.28.1-develop.0",
+  "version": "1.28.1",
   "description": "A client for interacting with ChannelApe's API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/orders/model/LineItem.ts
+++ b/src/orders/model/LineItem.ts
@@ -16,6 +16,6 @@ export default interface LineItem {
   vendor?: string;
   restockType?: string;
   taxes?: Tax[];
-  readonly giftCardCode?: string;
+  giftCardCode?: string;
   readonly giftCardId?: string;
 }

--- a/src/orders/service/JsonOrderFormatterService.ts
+++ b/src/orders/service/JsonOrderFormatterService.ts
@@ -23,7 +23,6 @@ export default class JsonOrderFormatterService {
     order.totalPrice = Number(order.totalPrice);
     order.subtotalPrice = Number(order.subtotalPrice);
     order.totalShippingPrice = Number(order.totalShippingPrice);
-    
     if (typeof order.totalShippingTax !== 'undefined') {
       order.totalShippingTax = Number(order.totalShippingTax);
     }
@@ -57,6 +56,6 @@ export default class JsonOrderFormatterService {
     tax.price = Number(tax.price);
     tax.rate = tax.rate ? Number(tax.rate) : undefined;
     return tax;
-  };
+  }
 
 }

--- a/src/orders/service/JsonOrderFormatterService.ts
+++ b/src/orders/service/JsonOrderFormatterService.ts
@@ -3,6 +3,7 @@ import OrderStatus from '../model/OrderStatus';
 import LineItem from '../model/LineItem';
 import Fulfillment from '../model/Fulfillment';
 import trimObject from '../../utils/trimObject';
+import Tax from '../model/Tax';
 
 export default class JsonOrderFormatterService {
   public static formatOrder(rawOrder: any): Order {
@@ -22,6 +23,7 @@ export default class JsonOrderFormatterService {
     order.totalPrice = Number(order.totalPrice);
     order.subtotalPrice = Number(order.subtotalPrice);
     order.totalShippingPrice = Number(order.totalShippingPrice);
+    
     if (typeof order.totalShippingTax !== 'undefined') {
       order.totalShippingTax = Number(order.totalShippingTax);
     }
@@ -45,6 +47,16 @@ export default class JsonOrderFormatterService {
   private static formatLineItem(lineItem: LineItem): LineItem {
     lineItem.grams = Number(lineItem.grams);
     lineItem.price = Number(lineItem.price);
+    if (typeof lineItem.taxes !== 'undefined') {
+      lineItem.taxes = lineItem.taxes.map(JsonOrderFormatterService.formatLineItemTax);
+    }
     return lineItem;
   }
+
+  private static formatLineItemTax(tax: Tax): Tax {
+    tax.price = Number(tax.price);
+    tax.rate = tax.rate ? Number(tax.rate) : undefined;
+    return tax;
+  };
+
 }

--- a/test/orders/service/JsonOrderFormatterService.spec.ts
+++ b/test/orders/service/JsonOrderFormatterService.spec.ts
@@ -58,8 +58,8 @@ describe('JsonOrderFormatterService', () => {
         const order = JsonOrderFormatterService.formatOrder(singleOrder.default);
         expect(order.id).to.equal('c0f45529-cbed-4e90-9a38-c208d409ef2a');
         expect(order.updatedAt.getFullYear()).to.equal(2018);
-        expect (order.lineItems.length).to.equals(2);
-        expect (order.lineItems[0].taxes).to.not.be.undefined;
+        expect(order.lineItems.length).to.equals(2);
+        expect(order.lineItems[0].taxes).to.not.be.undefined;
         // @ts-ignore
         expect(order.lineItems[0].taxes[0].price).to.equals(Number(9.99));
         // @ts-ignore
@@ -72,9 +72,6 @@ describe('JsonOrderFormatterService', () => {
         expect(order.lineItems[0].taxes[1].rate).to.be.undefined;
         // @ts-ignore
         expect(order.lineItems[0].taxes[1].title).to.equals('NV State Tax');
-        
-
-        
       });
     });
 

--- a/test/orders/service/JsonOrderFormatterService.spec.ts
+++ b/test/orders/service/JsonOrderFormatterService.spec.ts
@@ -55,7 +55,11 @@ describe('JsonOrderFormatterService', () => {
 
     describe('with all required order properties', () => {
       it('Return an Order', () => {
-        const order = JsonOrderFormatterService.formatOrder(singleOrder.default);
+        const anyOrder = JSON.parse(JSON.stringify(singleOrder.default));
+        anyOrder.lineItems[0].taxes[0].price = '9.99';
+        anyOrder.lineItems[0].taxes[0].rate = '0.06';
+        anyOrder.lineItems[0].taxes[1].price = '1.00';
+        const order = JsonOrderFormatterService.formatOrder(JSON.stringify(anyOrder));
         expect(order.id).to.equal('c0f45529-cbed-4e90-9a38-c208d409ef2a');
         expect(order.updatedAt.getFullYear()).to.equal(2018);
         expect(order.lineItems.length).to.equals(2);

--- a/test/orders/service/JsonOrderFormatterService.spec.ts
+++ b/test/orders/service/JsonOrderFormatterService.spec.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 
 import * as singleOrder from '../resources/singleOrder';
 import JsonOrderFormatterService from '../../../src/orders/service/JsonOrderFormatterService';
+import { fail } from 'assert';
 
 describe('JsonOrderFormatterService', () => {
   describe('Given a JSON string', () => {
@@ -45,6 +46,7 @@ describe('JsonOrderFormatterService', () => {
       it('Throw an error', () => {
         try {
           JsonOrderFormatterService.formatOrder({ id: 'order-id' });
+          fail('Expected exception to be thrown but none occurred');
         } catch (e) {
           expect(e.message).to.equal("Cannot read property 'map' of undefined");
         }
@@ -56,6 +58,23 @@ describe('JsonOrderFormatterService', () => {
         const order = JsonOrderFormatterService.formatOrder(singleOrder.default);
         expect(order.id).to.equal('c0f45529-cbed-4e90-9a38-c208d409ef2a');
         expect(order.updatedAt.getFullYear()).to.equal(2018);
+        expect (order.lineItems.length).to.equals(2);
+        expect (order.lineItems[0].taxes).to.not.be.undefined;
+        // @ts-ignore
+        expect(order.lineItems[0].taxes[0].price).to.equals(Number(9.99));
+        // @ts-ignore
+        expect(order.lineItems[0].taxes[0].rate).to.equals(Number(0.06));
+        // @ts-ignore
+        expect(order.lineItems[0].taxes[0].title).to.equals('PA State Tax');
+        // @ts-ignore
+        expect(order.lineItems[0].taxes[1].price).to.equals(Number(1.00));
+        // @ts-ignore
+        expect(order.lineItems[0].taxes[1].rate).to.be.undefined;
+        // @ts-ignore
+        expect(order.lineItems[0].taxes[1].title).to.equals('NV State Tax');
+        
+
+        
       });
     });
 


### PR DESCRIPTION
@mb-ca and @mvx24 not sure how i missed this but should fix the problem you are seeing with the tax fields not being correctly parsed.