### PR TITLE
Add missing call to requestCompleted()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "channelape-sdk",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "description": "A client for interacting with ChannelApe's API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/RequestClientWrapper.ts
+++ b/src/RequestClientWrapper.ts
@@ -155,6 +155,7 @@ export default class RequestClientWrapper {
               const apiErrors = e.response == null || e.response.data == null || e.response.data.errors == null
                 ? [] : e.response.data.errors;
               const finalError = new ChannelApeError(e.message, e.response, url, apiErrors);
+              this.requestCompleted();
               callback(finalError, e, e.body);
             } catch (e) {
               callback(new Error('API Error'), e, {});


### PR DESCRIPTION
This one error handling block in the SDK doesn't decrement the pendingRequests in the client so it could max out and the client will become unusable.