### PR TITLE
Adds the ability to do an exact match on the quicksearch API. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,10 +241,12 @@ channelApeClient.variants().search(variantsRequest)
 ````
 
 #### Get Variant Search Results for a SKU
+
 ````typescript
 const variantsRequest: VariantsSearchRequestBySku = {
   sku,
-  businessId
+  businessId,
+  exactMatch: true
 };
 channelApeClient.variants().search(variantsRequest)
   .then((variantSearchResults: VariantSearchResults[]) => {
@@ -256,7 +258,8 @@ channelApeClient.variants().search(variantsRequest)
 ````typescript
 const variantsRequest: VariantsSearchRequestByUpc = {
   upc,
-  businessId
+  businessId,
+  exactMatch: true
 };
 channelApeClient.variants().search(variantsRequest)
   .then((variantSearchResults: VariantSearchResults[]) => {

--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ channelApeClient.variants().search(variantsRequest)
 
 #### Get Variant Search Results for a SKU
 
+* *exactMatch* parameter if set to true will only match the exact sku set on the request instead of all sku's that start with that given character sequence.
+
 ````typescript
 const variantsRequest: VariantsSearchRequestBySku = {
   sku,
@@ -255,6 +257,9 @@ channelApeClient.variants().search(variantsRequest)
 ````
 
 #### Get Variant Search Results for a UPC
+
+* *exactMatch* parameter if set to true will only match the exact upc set on the request instead of all upc's that start with that given character sequence.
+
 ````typescript
 const variantsRequest: VariantsSearchRequestByUpc = {
   upc,

--- a/e2e/ChannelApeClient.spec.ts
+++ b/e2e/ChannelApeClient.spec.ts
@@ -666,7 +666,7 @@ describe('ChannelApe Client', () => {
               expect(actualVariants.length).to.be.greaterThan(1);
               const variant = actualVariants[0];
               expect(variant!.businessId).to.equal(expectedBusinessId);
-              expect(variant!.sku).to.equal("BH300136-SAGE-L");
+              expect(variant!.sku).to.equal('BH300136-SAGE-L');
             });
           });
         });

--- a/e2e/ChannelApeClient.spec.ts
+++ b/e2e/ChannelApeClient.spec.ts
@@ -615,7 +615,7 @@ describe('ChannelApe Client', () => {
 
       describe('And valid businessId and valid vendor', () => {
         context('When searching variants', () => {
-          it('Then return variant quick search results', () => {
+          it('And not using exact match with single result Then return variant quick search results', () => {
             const expectedVendor = 'Optimum Nutrition';
             const expectedBusinessId = '4baafa5b-4fbf-404e-9766-8a02ad45c3a4';
             const expectedSku = '2730117';
@@ -630,6 +630,43 @@ describe('ChannelApe Client', () => {
               expect(variant!.businessId).to.equal(expectedBusinessId);
               expect(variant!.vendor).to.equal(expectedVendor);
               expect(variant!.title).to.equal('Optimum Nutrition Opti-Women');
+            });
+          });
+
+          it('And using exact match with multiple variants Then return matching variant quick search variant', () => {
+            const expectedBusinessId = '4baafa5b-4fbf-404e-9766-8a02ad45c3a4';
+            const expectedSku = 'BH300136';
+            const variantsRequest: VariantsSearchRequestBySku = {
+              sku: expectedSku,
+              businessId: expectedBusinessId,
+              exactMatch: true,
+              size: 20
+            };
+            const actualVariantsPromise = channelApeClient.variants().search(variantsRequest);
+            return actualVariantsPromise.then((actualVariants) => {
+              expect(actualVariants).to.be.an('array');
+              expect(actualVariants.length).to.equals(1);
+              const variant = actualVariants[0];
+              expect(variant!.businessId).to.equal(expectedBusinessId);
+              expect(variant!.sku).to.equal(expectedSku);
+              expect(variant!.title).to.equal('Eldridge Plaid Coat');
+            });
+          });
+
+          it('And not using exact match with multiple results Then return variant quick search variant results', () => {
+            const expectedBusinessId = '4baafa5b-4fbf-404e-9766-8a02ad45c3a4';
+            const expectedSku = 'BH300136';
+            const variantsRequest: VariantsSearchRequestBySku = {
+              sku: expectedSku,
+              businessId: expectedBusinessId
+            };
+            const actualVariantsPromise = channelApeClient.variants().search(variantsRequest);
+            return actualVariantsPromise.then((actualVariants) => {
+              expect(actualVariants).to.be.an('array');
+              expect(actualVariants.length).to.be.greaterThan(1);
+              const variant = actualVariants[0];
+              expect(variant!.businessId).to.equal(expectedBusinessId);
+              expect(variant!.sku).to.equal("BH300136-SAGE-L");
             });
           });
         });

--- a/src/variants/model/VariantsSearchRequestBySku.ts
+++ b/src/variants/model/VariantsSearchRequestBySku.ts
@@ -3,5 +3,6 @@ import PaginationQueryRequest from '../../model/PaginationQueryRequest';
 
 export default interface VariantsSearchBySku extends VariantsSearchRequestByBusinessId, PaginationQueryRequest {
   sku: string;
+  exactMatch?: boolean;
   size?: number;
 }

--- a/src/variants/model/VariantsSearchRequestByUpc.ts
+++ b/src/variants/model/VariantsSearchRequestByUpc.ts
@@ -3,5 +3,6 @@ import PaginationQueryRequest from '../../model/PaginationQueryRequest';
 
 export default interface VariantsSearchRequestByUpc extends VariantsSearchRequestByBusinessId, PaginationQueryRequest {
   upc: string;
+  exactMatch?: boolean;
   size?: number;
 }

--- a/src/variants/service/VariantsService.ts
+++ b/src/variants/service/VariantsService.ts
@@ -118,7 +118,7 @@ export default class VariantsService {
         body
       };
       this.mapVariantsSearchPromise(requestUrl, deferred, requestResponse, variantSearchDetails,
-        <GenericVariantsSearchRequest> variantSearchRequest, EXPECTED_GET_STATUS, getSinglePage);
+        <GenericVariantsSearchRequest>variantSearchRequest, EXPECTED_GET_STATUS, getSinglePage);
     });
     return deferred.promise as any;
   }
@@ -126,7 +126,7 @@ export default class VariantsService {
   private getVariantByRequest(variantRequest: VariantsRequest, deferred: Q.Deferred<any>): void {
     const requestUrl = `/${Version.V1}${Resource.PRODUCTS}/${variantRequest.productId}${Resource.VARIANTS}/` +
       `${encodeURIComponent(variantRequest.inventoryItemValue)}`;
-    const options: AxiosRequestConfig = { };
+    const options: AxiosRequestConfig = {};
     this.client.get(requestUrl, options, (error, response, body) => {
       const requestResponse: RequestCallbackParams = {
         error,
@@ -140,7 +140,7 @@ export default class VariantsService {
   private getVariantsByRequest(variantsRequest: VariantsRequestByProductId, variants: Variant[],
     deferred: Q.Deferred<any>): void {
     const requestUrl = `/${Version.V1}${Resource.PRODUCTS}/${variantsRequest.productId}${Resource.VARIANTS}`;
-    const options: AxiosRequestConfig = { };
+    const options: AxiosRequestConfig = {};
     this.client.get(requestUrl, options, (error, response, body) => {
       const requestResponse: RequestCallbackParams = {
         error,
@@ -202,15 +202,15 @@ export default class VariantsService {
       const mergedVariantDetails: VariantSearchDetails[] = variantDetails.concat(variantSearchResults);
 
       if (getSinglePage) {
-        const variantSearchDetailsToReturn = variantsRequest.exactMatch 
-          ? this.filterOutNonExactMatches(mergedVariantDetails, variantsRequest) : mergedVariantDetails ;
+        const variantSearchDetailsToReturn = variantsRequest.exactMatch
+          ? this.filterOutNonExactMatches(mergedVariantDetails, variantsRequest) : mergedVariantDetails;
         deferred.resolve({
           variantSearchResults: variantSearchDetailsToReturn,
           pagination: data.pagination
         });
       } else if (data.pagination.lastPage) {
-        const variantSearchDetailsToReturn = variantsRequest.exactMatch 
-          ? this.filterOutNonExactMatches(mergedVariantDetails, variantsRequest) : mergedVariantDetails ;
+        const variantSearchDetailsToReturn = variantsRequest.exactMatch
+          ? this.filterOutNonExactMatches(mergedVariantDetails, variantsRequest) : mergedVariantDetails;
         deferred.resolve(variantSearchDetailsToReturn);
       } else {
         const newVariantsRequest: GenericVariantsSearchRequest = {
@@ -222,16 +222,19 @@ export default class VariantsService {
     } else {
       const channelApeErrorResponse =
         GenerateApiError(requestUrl, requestCallbackParams.response, requestCallbackParams.body,
-            EXPECTED_GET_STATUS);
+          EXPECTED_GET_STATUS);
       deferred.reject(channelApeErrorResponse);
     }
   }
 
-  private filterOutNonExactMatches(variantSearchDetails: VariantSearchDetails[], variantSearchRequest: GenericVariantsSearchRequest) {
+  private filterOutNonExactMatches(variantSearchDetails: VariantSearchDetails[],
+    variantSearchRequest: GenericVariantsSearchRequest) {
     return variantSearchDetails.filter((searchResult) => {
-      if(variantSearchRequest.sku && searchResult.sku.toLowerCase() !== variantSearchRequest.sku.toLowerCase()) {
+      if (variantSearchRequest.sku && searchResult.sku.toLowerCase() !== variantSearchRequest.sku.toLowerCase()) {
         return false;
-      } else if(variantSearchRequest.upc && searchResult.upc.toLowerCase() !== variantSearchRequest.upc.toLowerCase()) {
+      }
+      if (variantSearchRequest.upc &&
+        searchResult.upc.toLowerCase() !== variantSearchRequest.upc.toLowerCase()) {
         return false;
       }
       return true;

--- a/test/variants/resources/v1_products_variants_skus_0.json
+++ b/test/variants/resources/v1_products_variants_skus_0.json
@@ -2,7 +2,7 @@
   "errors": [],
   "pagination": {
     "lastPage": true,
-    "pageSize": 1
+    "pageSize": 2
   },
   "variantSearchResults": [
     {
@@ -12,6 +12,62 @@
       "sku": "6030038",
       "upc": "853385003971",
       "title": "Caveman Foods Chicken Jerky",
+      "vendor": "Caveman Foods",
+      "condition": "NEW",
+      "primaryCategory": "Snacks / Foods",
+      "secondaryCategory": "Snacks / Foods",
+      "tags": [
+        "FresnoCaliforniaQuantityOnHand_Yes",
+        "LasVegasNevadaQuantityOnHand_No",
+        "EuropaSports",
+        "CharlotteNorthCarolinaQuantityOnHand_Yes",
+        "WindsorConnecticutQuantityOnHand_Yes",
+        "MesquiteTexasQuantityOnHand_Yes",
+        "StrongsvilleOhioQuantityOnHand_Yes",
+        "WalmartCategoryParent_FoodAndBeverage",
+        "OrlandoFloridaQuantityOnHand_Yes"
+      ],
+      "grams": "70.8738078125",
+      "currencyCode": "USD",
+      "retailPrice": "8.99",
+      "wholesalePrice": "5.50",
+      "quantity": 0
+    },
+    {
+      "productId": "00050387-9bb1-4587-becc-ff951981d0f9",
+      "inventoryItemValue": "6030038",
+      "businessId": "4baafa5b-4fbf-404e-9766-8a02ad45c3a4",
+      "sku": "6030038-TEST-1",
+      "upc": "853385003971",
+      "title": "Caveman Foods Chicken Jerky2",
+      "vendor": "Caveman Foods",
+      "condition": "NEW",
+      "primaryCategory": "Snacks / Foods",
+      "secondaryCategory": "Snacks / Foods",
+      "tags": [
+        "FresnoCaliforniaQuantityOnHand_Yes",
+        "LasVegasNevadaQuantityOnHand_No",
+        "EuropaSports",
+        "CharlotteNorthCarolinaQuantityOnHand_Yes",
+        "WindsorConnecticutQuantityOnHand_Yes",
+        "MesquiteTexasQuantityOnHand_Yes",
+        "StrongsvilleOhioQuantityOnHand_Yes",
+        "WalmartCategoryParent_FoodAndBeverage",
+        "OrlandoFloridaQuantityOnHand_Yes"
+      ],
+      "grams": "70.8738078125",
+      "currencyCode": "USD",
+      "retailPrice": "8.99",
+      "wholesalePrice": "5.50",
+      "quantity": 0
+    },
+    {
+      "productId": "00050387-9bb1-4587-becc-ff951981d0f10",
+      "inventoryItemValue": "6030038",
+      "businessId": "4baafa5b-4fbf-404e-9766-8a02ad45c3a4",
+      "sku": "6030038-TEST-2",
+      "upc": "853385003971",
+      "title": "Caveman Foods Chicken Jerky3",
       "vendor": "Caveman Foods",
       "condition": "NEW",
       "primaryCategory": "Snacks / Foods",

--- a/test/variants/resources/v1_products_variants_upcs_0.json
+++ b/test/variants/resources/v1_products_variants_upcs_0.json
@@ -2,7 +2,7 @@
   "errors": [],
   "pagination": {
     "lastPage": true,
-    "pageSize": 1
+    "pageSize": 3
   },
   "variantSearchResults": [
     {
@@ -12,6 +12,62 @@
       "sku": "6030038",
       "upc": "853385003971",
       "title": "Caveman Foods Chicken Jerky",
+      "vendor": "Caveman Foods",
+      "condition": "NEW",
+      "primaryCategory": "Snacks / Foods",
+      "secondaryCategory": "Snacks / Foods",
+      "tags": [
+        "FresnoCaliforniaQuantityOnHand_Yes",
+        "LasVegasNevadaQuantityOnHand_No",
+        "EuropaSports",
+        "CharlotteNorthCarolinaQuantityOnHand_Yes",
+        "WindsorConnecticutQuantityOnHand_Yes",
+        "MesquiteTexasQuantityOnHand_Yes",
+        "StrongsvilleOhioQuantityOnHand_Yes",
+        "WalmartCategoryParent_FoodAndBeverage",
+        "OrlandoFloridaQuantityOnHand_Yes"
+      ],
+      "grams": "70.8738078125",
+      "currencyCode": "USD",
+      "retailPrice": "8.99",
+      "wholesalePrice": "5.50",
+      "quantity": 0
+    },
+    {
+      "productId": "00050387-9bb1-4587-becc-ff951981d0f8",
+      "inventoryItemValue": "6030038",
+      "businessId": "4baafa5b-4fbf-404e-9766-8a02ad45c3a4",
+      "sku": "6030038-",
+      "upc": "853385003971-TEST-1",
+      "title": "Caveman Foods Chicken Jerky2",
+      "vendor": "Caveman Foods",
+      "condition": "NEW",
+      "primaryCategory": "Snacks / Foods",
+      "secondaryCategory": "Snacks / Foods",
+      "tags": [
+        "FresnoCaliforniaQuantityOnHand_Yes",
+        "LasVegasNevadaQuantityOnHand_No",
+        "EuropaSports",
+        "CharlotteNorthCarolinaQuantityOnHand_Yes",
+        "WindsorConnecticutQuantityOnHand_Yes",
+        "MesquiteTexasQuantityOnHand_Yes",
+        "StrongsvilleOhioQuantityOnHand_Yes",
+        "WalmartCategoryParent_FoodAndBeverage",
+        "OrlandoFloridaQuantityOnHand_Yes"
+      ],
+      "grams": "70.8738078125",
+      "currencyCode": "USD",
+      "retailPrice": "8.99",
+      "wholesalePrice": "5.50",
+      "quantity": 0
+    },
+    {
+      "productId": "00050387-9bb1-4587-becc-ff951981d0f8",
+      "inventoryItemValue": "6030038",
+      "businessId": "4baafa5b-4fbf-404e-9766-8a02ad45c3a4",
+      "sku": "6030038-",
+      "upc": "853385003971-TEST-2",
+      "title": "Caveman Foods Chicken Jerky3",
       "vendor": "Caveman Foods",
       "condition": "NEW",
       "primaryCategory": "Snacks / Foods",

--- a/test/variants/service/VariantService.spec.ts
+++ b/test/variants/service/VariantService.spec.ts
@@ -396,16 +396,15 @@ describe('VariantsService', () => {
             expect(variant1!.vendor).to.equal('Caveman Foods');
             expect(variant1!.title).to.equal('Caveman Foods Chicken Jerky');
             const variant2 = actualVariants[1];
-            expect(variant2!.sku).to.equal(expectedSku + '-TEST-1');
+            expect(variant2!.sku).to.equal('6030038-TEST-1');
             expect(variant2!.businessId).to.equal(expectedBusinessId);
             expect(variant2!.vendor).to.equal('Caveman Foods');
             expect(variant2!.title).to.equal('Caveman Foods Chicken Jerky2');
             const variant3 = actualVariants[2];
-            expect(variant3!.sku).to.equal(expectedSku + '-TEST-2');
+            expect(variant3!.sku).to.equal('6030038-TEST-2');
             expect(variant3!.businessId).to.equal(expectedBusinessId);
             expect(variant3!.vendor).to.equal('Caveman Foods');
             expect(variant3!.title).to.equal('Caveman Foods Chicken Jerky3');
-            
           });
         });
 
@@ -433,8 +432,6 @@ describe('VariantsService', () => {
             expect(variant1!.sku).to.equal(expectedSku);
             expect(variant1!.vendor).to.equal('Caveman Foods');
             expect(variant1!.title).to.equal('Caveman Foods Chicken Jerky');
-            const variant2 = actualVariants[1];
-            
           });
         });
       });
@@ -492,12 +489,12 @@ describe('VariantsService', () => {
             expect(variant1!.vendor).to.equal('Caveman Foods');
             expect(variant1!.title).to.equal('Caveman Foods Chicken Jerky');
             const variant2 = actualVariants[1];
-            expect(variant2!.upc).to.equal(expectedUpc + "-TEST-1");
+            expect(variant2!.upc).to.equal('853385003971-TEST-1');
             expect(variant2!.businessId).to.equal(expectedBusinessId);
             expect(variant2!.vendor).to.equal('Caveman Foods');
             expect(variant2!.title).to.equal('Caveman Foods Chicken Jerky2');
             const variant3 = actualVariants[2];
-            expect(variant3!.upc).to.equal(expectedUpc + "-TEST-2");
+            expect(variant3!.upc).to.equal('853385003971-TEST-2');
             expect(variant3!.businessId).to.equal(expectedBusinessId);
             expect(variant3!.vendor).to.equal('Caveman Foods');
             expect(variant3!.title).to.equal('Caveman Foods Chicken Jerky3');

--- a/test/variants/service/VariantService.spec.ts
+++ b/test/variants/service/VariantService.spec.ts
@@ -372,7 +372,7 @@ describe('VariantsService', () => {
 
     describe('And valid businessId and valid sku', () => {
       context('When searching variants', () => {
-        it('Then return variant quick search results', () => {
+        it('And not doing exact match, Then return all variant quick search results', () => {
           const expectedBusinessId = '4baafa5b-4fbf-404e-9766-8a02ad45c3a4';
           const expectedSku = '6030038';
           const variantsRequest: VariantsSearchRequestBySku = {
@@ -389,11 +389,52 @@ describe('VariantsService', () => {
           const actualVariantsPromise = variantsService.search(variantsRequest);
           return actualVariantsPromise.then((actualVariants) => {
             expect(actualVariants).to.be.an('array');
+            expect(actualVariants.length).to.equal(3);
+            const variant1 = actualVariants[0];
+            expect(variant1!.businessId).to.equal(expectedBusinessId);
+            expect(variant1!.sku).to.equal(expectedSku);
+            expect(variant1!.vendor).to.equal('Caveman Foods');
+            expect(variant1!.title).to.equal('Caveman Foods Chicken Jerky');
+            const variant2 = actualVariants[1];
+            expect(variant2!.sku).to.equal(expectedSku + '-TEST-1');
+            expect(variant2!.businessId).to.equal(expectedBusinessId);
+            expect(variant2!.vendor).to.equal('Caveman Foods');
+            expect(variant2!.title).to.equal('Caveman Foods Chicken Jerky2');
+            const variant3 = actualVariants[2];
+            expect(variant3!.sku).to.equal(expectedSku + '-TEST-2');
+            expect(variant3!.businessId).to.equal(expectedBusinessId);
+            expect(variant3!.vendor).to.equal('Caveman Foods');
+            expect(variant3!.title).to.equal('Caveman Foods Chicken Jerky3');
+            
+          });
+        });
+
+        it('And doing exact match, Then return only matched variant quick search result', () => {
+          const expectedBusinessId = '4baafa5b-4fbf-404e-9766-8a02ad45c3a4';
+          const expectedSku = '6030038';
+          const variantsRequest: VariantsSearchRequestBySku = {
+            sku: expectedSku,
+            businessId: expectedBusinessId,
+            exactMatch: true
+          };
+
+          const mockedAxiosAdapter = new axiosMockAdapter(axios);
+          const baseUrl = `${Environment.STAGING}/${Version.V1}${Resource.PRODUCTS}`;
+          mockedAxiosAdapter.onGet(`${baseUrl}${Resource.VARIANTS}${Resource.SKUS}`, {
+            params: variantsRequest
+          }).reply(200, getVariantsBySku);
+
+          const actualVariantsPromise = variantsService.search(variantsRequest);
+          return actualVariantsPromise.then((actualVariants) => {
+            expect(actualVariants).to.be.an('array');
             expect(actualVariants.length).to.equal(1);
-            const variant = actualVariants.find(v => v.sku === expectedSku);
-            expect(variant!.businessId).to.equal(expectedBusinessId);
-            expect(variant!.vendor).to.equal('Caveman Foods');
-            expect(variant!.title).to.equal('Caveman Foods Chicken Jerky');
+            const variant1 = actualVariants[0];
+            expect(variant1!.businessId).to.equal(expectedBusinessId);
+            expect(variant1!.sku).to.equal(expectedSku);
+            expect(variant1!.vendor).to.equal('Caveman Foods');
+            expect(variant1!.title).to.equal('Caveman Foods Chicken Jerky');
+            const variant2 = actualVariants[1];
+            
           });
         });
       });
@@ -401,12 +442,13 @@ describe('VariantsService', () => {
 
     describe('And valid businessId and valid upc', () => {
       context('When searching variants', () => {
-        it('Then return variant quick search results', () => {
+        it('And doing exact match, Then return variant quick search results', () => {
           const expectedBusinessId = '4baafa5b-4fbf-404e-9766-8a02ad45c3a4';
           const expectedUpc = '853385003971';
           const variantsRequest: VariantsSearchRequestByUpc = {
             upc: expectedUpc,
-            businessId: expectedBusinessId
+            businessId: expectedBusinessId,
+            exactMatch: true
           };
 
           const mockedAxiosAdapter = new axiosMockAdapter(axios);
@@ -423,6 +465,42 @@ describe('VariantsService', () => {
             expect(variant!.businessId).to.equal(expectedBusinessId);
             expect(variant!.vendor).to.equal('Caveman Foods');
             expect(variant!.title).to.equal('Caveman Foods Chicken Jerky');
+          });
+        });
+
+        it('And not doing exact match, Then return matching variant quick search result', () => {
+          const expectedBusinessId = '4baafa5b-4fbf-404e-9766-8a02ad45c3a4';
+          const expectedUpc = '853385003971';
+          const variantsRequest: VariantsSearchRequestByUpc = {
+            upc: expectedUpc,
+            businessId: expectedBusinessId
+          };
+
+          const mockedAxiosAdapter = new axiosMockAdapter(axios);
+          const baseUrl = `${Environment.STAGING}/${Version.V1}${Resource.PRODUCTS}`;
+          mockedAxiosAdapter.onGet(`${baseUrl}${Resource.VARIANTS}${Resource.UPCS}`, {
+            params: variantsRequest
+          }).reply(200, getVariantsByUpc);
+
+          const actualVariantsPromise = variantsService.search(variantsRequest);
+          return actualVariantsPromise.then((actualVariants) => {
+            expect(actualVariants).to.be.an('array');
+            expect(actualVariants.length).to.equal(3);
+            const variant1 = actualVariants[0];
+            expect(variant1!.upc).to.equal(expectedUpc);
+            expect(variant1!.businessId).to.equal(expectedBusinessId);
+            expect(variant1!.vendor).to.equal('Caveman Foods');
+            expect(variant1!.title).to.equal('Caveman Foods Chicken Jerky');
+            const variant2 = actualVariants[1];
+            expect(variant2!.upc).to.equal(expectedUpc + "-TEST-1");
+            expect(variant2!.businessId).to.equal(expectedBusinessId);
+            expect(variant2!.vendor).to.equal('Caveman Foods');
+            expect(variant2!.title).to.equal('Caveman Foods Chicken Jerky2');
+            const variant3 = actualVariants[2];
+            expect(variant3!.upc).to.equal(expectedUpc + "-TEST-2");
+            expect(variant3!.businessId).to.equal(expectedBusinessId);
+            expect(variant3!.vendor).to.equal('Caveman Foods');
+            expect(variant3!.title).to.equal('Caveman Foods Chicken Jerky3');
           });
         });
       });


### PR DESCRIPTION
Quick search does a like search when searching for SKU's, so if you have multiple skus that are similar there is a chance you can get back multiple in the response. This allows for you to do an exact match on the sku in the request.