### PR TITLE
Adds Api Account ID to sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "channelape-sdk",
-  "version": "1.31.0-develop.0",
+  "version": "1.30.0-develop.3",
   "description": "A client for interacting with ChannelApe's API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "channelape-sdk",
-  "version": "1.30.0-develop.2",
+  "version": "1.31.0-develop.0",
   "description": "A client for interacting with ChannelApe's API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/businesses/apiaccounts/model/ApiAccount.ts
+++ b/src/businesses/apiaccounts/model/ApiAccount.ts
@@ -1,0 +1,12 @@
+import ChannelApeApiError from '../../../model/ChannelApeApiError';
+
+export default interface ApiAccount {
+    id: string;
+    businessId: string;
+    name: string;
+    errors?: ChannelApeApiError[];
+    lastAccessedTime?: Date;
+    creationTime?: Date;
+    expired?: boolean;
+  }
+  

--- a/src/businesses/apiaccounts/model/ApiAccount.ts
+++ b/src/businesses/apiaccounts/model/ApiAccount.ts
@@ -1,12 +1,11 @@
 import ChannelApeApiError from '../../../model/ChannelApeApiError';
 
 export default interface ApiAccount {
-    id: string;
-    businessId: string;
-    name: string;
-    errors?: ChannelApeApiError[];
-    lastAccessedTime?: Date;
-    creationTime?: Date;
-    expired?: boolean;
-  }
-  
+  id: string;
+  businessId: string;
+  name: string;
+  errors?: ChannelApeApiError[];
+  lastAccessedTime?: Date;
+  creationTime?: Date;
+  expired?: boolean;
+}

--- a/src/businesses/apiaccounts/service/ApiAccountsService.ts
+++ b/src/businesses/apiaccounts/service/ApiAccountsService.ts
@@ -1,10 +1,10 @@
-import RequestClientWrapper from "../../../RequestClientWrapper";
-import Resource from "../../../model/Resource";
-import Version from "../../../model/Version";
-import Q = require("q");
-import { AxiosResponse } from "axios";
-import GenerateApiError from "../../../utils/GenerateApiError";
-import ApiAccount from "../model/ApiAccount";
+import RequestClientWrapper from '../../../RequestClientWrapper';
+import Resource from '../../../model/Resource';
+import Version from '../../../model/Version';
+import q = require('q');
+import { AxiosResponse } from 'axios';
+import GenerateApiError from '../../../utils/GenerateApiError';
+import ApiAccount from '../model/ApiAccount';
 
 const EXPECTED_GET_STATUS = 200;
 
@@ -13,7 +13,7 @@ export default class ApiAccountsService {
   constructor(private readonly client: RequestClientWrapper) {}
 
   public get(businessId: string, apiAccountId: string): Promise<ApiAccount> {
-    const deferred = Q.defer<ApiAccount>();
+    const deferred = q.defer<ApiAccount>();
     const requestUrl = `/${Version.V1}${Resource.BUSINESSES}/${businessId}${Resource.API_ACCOUNTS}/${apiAccountId}`;
     this.client.get(requestUrl, {}, (error, response, body) => {
       this.mapApiAccountPromise(requestUrl, deferred, error, response, body, EXPECTED_GET_STATUS);
@@ -21,7 +21,8 @@ export default class ApiAccountsService {
     return deferred.promise as any;
   }
 
-  private mapApiAccountPromise(requestUrl: string, deferred: Q.Deferred<ApiAccount>, error: any, response: AxiosResponse,
+  private mapApiAccountPromise(requestUrl: string, deferred: Q.Deferred<ApiAccount>, error: any,
+    response: AxiosResponse,
     body: any, expectedStatusCode: number) {
     if (error) {
       deferred.reject(error);

--- a/src/businesses/apiaccounts/service/ApiAccountsService.ts
+++ b/src/businesses/apiaccounts/service/ApiAccountsService.ts
@@ -1,0 +1,42 @@
+import RequestClientWrapper from "../../../RequestClientWrapper";
+import Resource from "../../../model/Resource";
+import Version from "../../../model/Version";
+import Q = require("q");
+import { AxiosResponse } from "axios";
+import GenerateApiError from "../../../utils/GenerateApiError";
+import ApiAccount from "../model/ApiAccount";
+
+const EXPECTED_GET_STATUS = 200;
+
+export default class ApiAccountsService {
+
+  constructor(private readonly client: RequestClientWrapper) {}
+
+  public get(businessId: string, apiAccountId: string): Promise<ApiAccount> {
+    const deferred = Q.defer<ApiAccount>();
+    const requestUrl = `/${Version.V1}${Resource.BUSINESSES}/${businessId}${Resource.API_ACCOUNTS}/${apiAccountId}`;
+    this.client.get(requestUrl, {}, (error, response, body) => {
+      this.mapApiAccountPromise(requestUrl, deferred, error, response, body, EXPECTED_GET_STATUS);
+    });
+    return deferred.promise as any;
+  }
+
+  private mapApiAccountPromise(requestUrl: string, deferred: Q.Deferred<ApiAccount>, error: any, response: AxiosResponse,
+    body: any, expectedStatusCode: number) {
+    if (error) {
+      deferred.reject(error);
+    } else if (response.status === expectedStatusCode) {
+      const apiAccount: ApiAccount = this.formatApiAccount(body);
+      deferred.resolve(apiAccount);
+    } else {
+      const channelApeErrorResponse = GenerateApiError(requestUrl, response, body, EXPECTED_GET_STATUS);
+      deferred.reject(channelApeErrorResponse);
+    }
+  }
+
+  private formatApiAccount(apiAccount: any): ApiAccount {
+    apiAccount.creationTime = new Date(apiAccount.creationTime);
+    apiAccount.lastAccessedTime = new Date(apiAccount.lastAccessedTime);
+    return apiAccount as ApiAccount;
+  }
+}

--- a/src/model/Resource.ts
+++ b/src/model/Resource.ts
@@ -19,7 +19,8 @@ enum Resource {
   USERS = '/users',
   INVENTORIES = '/inventories',
   LOCATIONS = '/locations',
-  STEPS = '/steps'
+  STEPS = '/steps',
+  API_ACCOUNTS = "/apiaccounts"
 }
 
 export default Resource;

--- a/src/model/Resource.ts
+++ b/src/model/Resource.ts
@@ -20,7 +20,7 @@ enum Resource {
   INVENTORIES = '/inventories',
   LOCATIONS = '/locations',
   STEPS = '/steps',
-  API_ACCOUNTS = "/apiaccounts"
+  API_ACCOUNTS = '/apiaccounts'
 }
 
 export default Resource;

--- a/src/sessions/model/Session.ts
+++ b/src/sessions/model/Session.ts
@@ -1,5 +1,5 @@
 export default interface Session {
   sessionId: string;
   userId: string;
-  apiAccountId: string;
+  apiAccountId?: string;
 }

--- a/src/sessions/model/Session.ts
+++ b/src/sessions/model/Session.ts
@@ -1,4 +1,5 @@
 export default interface Session {
   sessionId: string;
   userId: string;
+  apiAccountId: string;
 }

--- a/test/businesses/apiaccounts/service/ApiAccountsService.spec.ts
+++ b/test/businesses/apiaccounts/service/ApiAccountsService.spec.ts
@@ -6,7 +6,6 @@ import Version from './../../../../src/model/Version';
 import Resource from './../../../../src/model/Resource';
 import Environment from './../../../../src/model/Environment';
 import ChannelApeApiErrorResponse from './../../../../src/model/ChannelApeApiErrorResponse';
-import Channel from './../../../../src/channels/model/Channel';
 import RequestClientWrapper from './../../../../src/RequestClientWrapper';
 import { ChannelApeError } from './../../../../src/index';
 import ApiAccount from './../../../../src/businesses/apiaccounts/model/ApiAccount';
@@ -29,13 +28,13 @@ describe('Api Accounts Service', () => {
     let sandbox: sinon.SinonSandbox;
 
     const expectedApiAccount: ApiAccount = {
-        businessId: "4baafa5b-4fbf-404e-9766-8a02ad45c3a4",
-        creationTime: new Date("2019-09-05T20:22:19.737Z"),
-        errors: [],
-        id: "14bc4780-f2c0-48d6-8e9a-41e6816c55eb",
-        name: "Update Orders Playbook Step",
-        lastAccessedTime: new Date("2020-09-05T20:22:19.737Z"),
-        expired: true
+      businessId: '4baafa5b-4fbf-404e-9766-8a02ad45c3a4',
+      creationTime: new Date('2019-09-05T20:22:19.737Z'),
+      errors: [],
+      id: '14bc4780-f2c0-48d6-8e9a-41e6816c55eb',
+      name: 'Update Orders Playbook Step',
+      lastAccessedTime: new Date('2020-09-05T20:22:19.737Z'),
+      expired: true
     };
 
     const expectedChannelApeErrorResponse: ChannelApeApiErrorResponse = {
@@ -62,9 +61,8 @@ describe('Api Accounts Service', () => {
       done();
     });
 
-    it('And valid API Account ID ' +
-      'When retrieving API Account for business Then return resolved promise with API Account', () => {
-
+    it(`And valid API Account ID When retrieving API Account for business
+    Then return resolved promise with API Account`, () => {
       const response = {
         status: 200,
         config: {
@@ -73,7 +71,6 @@ describe('Api Accounts Service', () => {
       };
       const clientGetStub: sinon.SinonStub = sandbox.stub(client, 'get')
         .yields(null, response, expectedApiAccount);
-
       const apiAccountsService: ApiAccountsService = new ApiAccountsService(client);
       return apiAccountsService.get(expectedApiAccount.businessId, expectedApiAccount.id).then((actualAction) => {
         expect(clientGetStub.args[0][0]).to.equal(`/${Version.V1}${Resource.BUSINESSES}/${expectedApiAccount.businessId}${Resource.API_ACCOUNTS}/${expectedApiAccount.id}`);
@@ -81,9 +78,8 @@ describe('Api Accounts Service', () => {
       });
     });
 
-    it('And not found API Account ID ' +
-      'When retrieving API Account ID for business Then return resolved promise with error', () => {
-
+    it(`And not found API Account ID When retrieving API
+    Account ID for business Then return resolved promise with error`, () => {
       const response = {
         status: 404,
         config: {
@@ -100,9 +96,8 @@ describe('Api Accounts Service', () => {
       });
     });
 
-    it('And unexpected error occurs ' +
-      'When retrieving API Account ID for business Then return rejected promise with error', () => {
-
+    it(`And unexpected error occurs
+    When retrieving API Account ID for business Then return rejected promise with error`, () => {
       const clientGetStub: sinon.SinonStub = sandbox.stub(client, 'get')
         .yields(expectedError, null, null);
 
@@ -112,7 +107,6 @@ describe('Api Accounts Service', () => {
         expect(e).to.equal(expectedError);
       });
     });
-
 
     function expectApiAccount(actualApiAccount: ApiAccount) {
       expect(actualApiAccount.id).to.equal(expectedApiAccount.id);

--- a/test/businesses/apiaccounts/service/ApiAccountsService.spec.ts
+++ b/test/businesses/apiaccounts/service/ApiAccountsService.spec.ts
@@ -1,0 +1,130 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import LogLevel from './../../../../src/model/LogLevel';
+import ApiAccountsService from './../../../../src/businesses/apiaccounts/service/ApiAccountsService';
+import Version from './../../../../src/model/Version';
+import Resource from './../../../../src/model/Resource';
+import Environment from './../../../../src/model/Environment';
+import ChannelApeApiErrorResponse from './../../../../src/model/ChannelApeApiErrorResponse';
+import Channel from './../../../../src/channels/model/Channel';
+import RequestClientWrapper from './../../../../src/RequestClientWrapper';
+import { ChannelApeError } from './../../../../src/index';
+import ApiAccount from './../../../../src/businesses/apiaccounts/model/ApiAccount';
+
+describe('Api Accounts Service', () => {
+
+  describe('Given some rest client', () => {
+    const client: RequestClientWrapper =
+      new RequestClientWrapper({
+        endpoint: Environment.STAGING,
+        maximumRequestRetryTimeout: 10000,
+        timeout: 60000,
+        session: 'valid-session-id',
+        logLevel: LogLevel.INFO,
+        minimumRequestRetryRandomDelay: 50,
+        maximumRequestRetryRandomDelay: 50,
+        maximumConcurrentConnections: 5
+      });
+
+    let sandbox: sinon.SinonSandbox;
+
+    const expectedApiAccount: ApiAccount = {
+        businessId: "4baafa5b-4fbf-404e-9766-8a02ad45c3a4",
+        creationTime: new Date("2019-09-05T20:22:19.737Z"),
+        errors: [],
+        id: "14bc4780-f2c0-48d6-8e9a-41e6816c55eb",
+        name: "Update Orders Playbook Step",
+        lastAccessedTime: new Date("2020-09-05T20:22:19.737Z"),
+        expired: true
+    };
+
+    const expectedChannelApeErrorResponse: ChannelApeApiErrorResponse = {
+      statusCode: 404,
+      errors: [
+        {
+          code: 70,
+          message: 'Api Account could not be found for business.'
+        }
+      ]
+    };
+
+    const expectedError = {
+      stack: 'oh no an error'
+    };
+
+    beforeEach((done) => {
+      sandbox = sinon.createSandbox();
+      done();
+    });
+
+    afterEach((done) => {
+      sandbox.restore();
+      done();
+    });
+
+    it('And valid API Account ID ' +
+      'When retrieving API Account for business Then return resolved promise with API Account', () => {
+
+      const response = {
+        status: 200,
+        config: {
+          method: 'GET'
+        }
+      };
+      const clientGetStub: sinon.SinonStub = sandbox.stub(client, 'get')
+        .yields(null, response, expectedApiAccount);
+
+      const apiAccountsService: ApiAccountsService = new ApiAccountsService(client);
+      return apiAccountsService.get(expectedApiAccount.businessId, expectedApiAccount.id).then((actualAction) => {
+        expect(clientGetStub.args[0][0]).to.equal(`/${Version.V1}${Resource.BUSINESSES}/${expectedApiAccount.businessId}${Resource.API_ACCOUNTS}/${expectedApiAccount.id}`);
+        expectApiAccount(expectedApiAccount);
+      });
+    });
+
+    it('And not found API Account ID ' +
+      'When retrieving API Account ID for business Then return resolved promise with error', () => {
+
+      const response = {
+        status: 404,
+        config: {
+          method: 'GET'
+        }
+      };
+      const clientGetStub: sinon.SinonStub = sandbox.stub(client, 'get')
+        .yields(null, response, expectedChannelApeErrorResponse);
+
+      const apiAccountsService: ApiAccountsService = new ApiAccountsService(client);
+      return apiAccountsService.get(expectedApiAccount.businessId, expectedApiAccount.id).catch((e) => {
+        expect(clientGetStub.args[0][0]).to.equal(`/${Version.V1}${Resource.BUSINESSES}/${expectedApiAccount.businessId}${Resource.API_ACCOUNTS}/${expectedApiAccount.id}`);
+        expectChannelApeErrorResponse(e);
+      });
+    });
+
+    it('And unexpected error occurs ' +
+      'When retrieving API Account ID for business Then return rejected promise with error', () => {
+
+      const clientGetStub: sinon.SinonStub = sandbox.stub(client, 'get')
+        .yields(expectedError, null, null);
+
+      const apiAccountsService: ApiAccountsService = new ApiAccountsService(client);
+      return apiAccountsService.get(expectedApiAccount.businessId, expectedApiAccount.id).catch((e) => {
+        expect(clientGetStub.args[0][0]).to.equal(`/${Version.V1}${Resource.BUSINESSES}/${expectedApiAccount.businessId}${Resource.API_ACCOUNTS}/${expectedApiAccount.id}`);
+        expect(e).to.equal(expectedError);
+      });
+    });
+
+
+    function expectApiAccount(actualApiAccount: ApiAccount) {
+      expect(actualApiAccount.id).to.equal(expectedApiAccount.id);
+      expect(actualApiAccount.businessId).to.equal(expectedApiAccount.businessId);
+    }
+
+    function expectChannelApeErrorResponse(error: ChannelApeError) {
+      expect(error.Response.statusCode).to.equal(404);
+      expect(error.ApiErrors[0].code).to.equal(expectedChannelApeErrorResponse.errors[0].code);
+      expect(error.ApiErrors[0].message)
+        .to.equal(expectedChannelApeErrorResponse.errors[0].message);
+    }
+
+  });
+});

--- a/test/sessions/service/SessionsService.spec.ts
+++ b/test/sessions/service/SessionsService.spec.ts
@@ -27,6 +27,7 @@ describe('Sessions Service', () => {
       });
     const sessionId = 'b40da0b8-a770-4de7-a496-361254bd7d6c';
     const userId = 'f6ed6f7a-47bf-4dd3-baed-71a8a9684e80';
+    const apiAccountId = 'a6ed6f7a-47bf-4dd3-baed-71a8a9684e80';
     const sessionsService = new SessionsService(client);
 
     let sandbox: sinon.SinonSandbox;
@@ -61,6 +62,30 @@ describe('Sessions Service', () => {
         expect(clientGetStub.args[0][0])
             .to.equal(`/${Version.V1}${Resource.SESSIONS}/${sessionId}`);
         expect(actualResponse.userId).to.equal(expectedResponse.userId);
+        expect(actualResponse.sessionId).to.equal(expectedResponse.sessionId);
+      });
+    });
+
+    it('And session ID is valid with API Account ID ' +
+      'When retrieving session Then return resolved promise with session data', () => {
+
+      const expectedResponse = {
+        sessionId,
+        apiAccountId
+      };
+
+      const response = {
+        status: 200,
+        config: {},
+        data: expectedResponse
+      };
+
+      const clientGetStub = sandbox.stub(axios, 'get').resolves(response);
+
+      return sessionsService.get(sessionId).then((actualResponse) => {
+        expect(clientGetStub.args[0][0])
+            .to.equal(`/${Version.V1}${Resource.SESSIONS}/${sessionId}`);
+        expect(actualResponse.apiAccountId).to.equal(expectedResponse.apiAccountId);
         expect(actualResponse.sessionId).to.equal(expectedResponse.sessionId);
       });
     });


### PR DESCRIPTION
API account private keys are just long lived sessions. When you make a request to get this session, the apiAccountId is the field populated since it's not associated with a specific user.