### PR TITLE
Added nullable playSettings property to Supplier type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "channelape-sdk",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "description": "A client for interacting with ChannelApe's API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/suppliers/model/Supplier.ts
+++ b/src/suppliers/model/Supplier.ts
@@ -1,4 +1,5 @@
 import FileSettings from '../../model/fileSettings/FileSettings';
+import PlaySettings from './PlaySettings';
 import StepSettings from './StepSettings';
 
 export default interface Supplier {
@@ -9,6 +10,7 @@ export default interface Supplier {
   id: string;
   integrationId: string;
   name: string;
+  playSettings?: PlaySettings;
   stepSettings?: StepSettings;
   synchronous?: boolean;
   updatedAt: Date;


### PR DESCRIPTION
Quick fix to add the missing ChannelApe Supplier Type nullable property: `playSettings` 